### PR TITLE
YaruCarousel: many improvements

### DIFF
--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -5,18 +5,18 @@ const _kAnimationDuration = Duration(milliseconds: 500);
 const _kAnimationCurve = Curves.easeInOutCubic;
 
 class YaruCarousel extends StatefulWidget {
-  const YaruCarousel(
-      {Key? key,
-      this.height = 500,
-      this.width = 500,
-      required this.children,
-      this.initialIndex = 0,
-      this.autoScroll = false,
-      this.autoScrollDuration = const Duration(seconds: 1),
-      this.placeIndicator = true,
-      this.placeIndicatorMarginTop = 12.0,
-      this.viewportFraction = 0.8})
-      : super(key: key);
+  const YaruCarousel({
+    Key? key,
+    this.height = 500,
+    this.width = 500,
+    required this.children,
+    this.initialIndex = 0,
+    this.autoScroll = false,
+    this.autoScrollDuration = const Duration(seconds: 1),
+    this.placeIndicator = true,
+    this.placeIndicatorMarginTop = 12.0,
+    this.viewportFraction = 0.8,
+  }) : super(key: key);
 
   /// The height of the children, defaults to 500.0.
   final double height;


### PR DESCRIPTION
### Add animation on dot index change

https://user-images.githubusercontent.com/36476595/170045549-e31cb2a0-7f1c-4417-a4a4-d15e70a91797.mp4


### Better responsive place indicator layout

https://user-images.githubusercontent.com/36476595/170045628-3f009a7d-2be0-4d61-a3e8-eebee5834f51.mp4

### Remove inconsistent margin

**Before:**

The margin is not the same on each edge.

![image](https://user-images.githubusercontent.com/36476595/170048173-d20c076d-70a5-4268-8422-070d20d728bf.png)

**After:**

Now the widget reach each edge.
You can add your own `Padding` around, and customize the space between carousel and indicator.

![image](https://user-images.githubusercontent.com/36476595/170049429-4f35604b-4484-4f25-8328-87815d5cc6cd.png)

**Note:** @Feichtmeier I saw you added a new `margin` property in #135, but I removed it here because I think it is no more needed with those new changes.