### PR TITLE
fix: make the icon page work in the github pages web page build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,3 +22,4 @@ jobs:
           workingDir: example
           baseHref: /yaru.dart/
           webRenderer: canvaskit
+          customArgs: --no-tree-shake-icons

--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -26,7 +26,7 @@ class BannerPage extends StatelessWidget {
             for (int i = 0; i < 20; i++)
               YaruWatermark(
                 watermark: const Icon(
-                  Icons.cloud,
+                  YaruIcons.cloud,
                   size: 100,
                 ),
                 child: _Banner(i: i),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,8 +27,6 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
-  uses-material-design: true
-
   assets:
     - assets/
   fonts:


### PR DESCRIPTION
The problem comes from the icons tree shake, so let's disable : it is not needed because we are theoretically using all the icons.
I also disabled the import of material icons, because the full file is 2Mo 😅
I replaced the only two material icons we were using in the example app, so we doesn't need to import it any more.

Fixes #857 