### PR TITLE
fix(YaruSearchField): display clear button on _controller text change

### DIFF
--- a/lib/src/widgets/yaru_search_field.dart
+++ b/lib/src/widgets/yaru_search_field.dart
@@ -92,6 +92,15 @@ class _YaruSearchFieldState extends State<YaruSearchField> {
     super.initState();
     _controller = widget.controller ?? TextEditingController(text: widget.text);
     _focusNode = widget.focusNode ?? FocusNode();
+
+    var isInputEmpty = _controller.text.isEmpty;
+    _controller.addListener(() {
+      if (isInputEmpty != _controller.text.isEmpty) {
+        setState(() {
+          isInputEmpty = _controller.text.isEmpty;
+        });
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
The widget wasn't rebuild on _controller text change.

**Before:**

[Capture vidéo du 2024-03-03 14-33-39.webm](https://github.com/ubuntu/yaru.dart/assets/36476595/a8a9624d-4322-4de5-a5e8-52d051c25588)

**After:**

[Capture vidéo du 2024-03-03 14-33-04.webm](https://github.com/ubuntu/yaru.dart/assets/36476595/86f6a214-cf67-49d9-aea4-5824526e5357)