### PR TITLE
fix: Styling issue with YaruPopupMenuButton

### DIFF
--- a/example/lib/pages/theme_page/src/controls/chips.dart
+++ b/example/lib/pages/theme_page/src/controls/chips.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import '../constants.dart';
 
@@ -13,6 +14,7 @@ class Chips extends StatelessWidget {
       children: [
         const Chip(label: Text('Ch-ch-ch-Chip n Dale')),
         Chip(
+          deleteIcon: const Icon(YaruIcons.window_close),
           label: const Text('Rescue Rangers'),
           onDeleted: () {},
         ),

--- a/example/lib/pages/theme_page/src/controls/toggleables.dart
+++ b/example/lib/pages/theme_page/src/controls/toggleables.dart
@@ -72,7 +72,8 @@ class _ToggleablesState extends State<Toggleables> {
             ),
           ],
         ),
-        Row(
+        Wrap(
+          spacing: 10,
           children: [
             Switch(onChanged: (value) {}, value: true),
             Switch(onChanged: (value) {}, value: false),
@@ -80,7 +81,9 @@ class _ToggleablesState extends State<Toggleables> {
             const Switch(value: false, onChanged: null),
           ],
         ),
-        Row(
+        Wrap(
+          spacing: 10,
+          runSpacing: 10,
           children: [
             ToggleButtons(
               isSelected: const [true, false, false],

--- a/example/lib/pages/theme_page/src/textfields/text_fields_view.dart
+++ b/example/lib/pages/theme_page/src/textfields/text_fields_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import '../constants.dart';
 
@@ -90,6 +91,8 @@ class _TextFieldsViewState extends State<TextFieldsView> {
         maxLines: 5,
       ),
       const DropdownMenu(
+        trailingIcon: Icon(YaruIcons.pan_down),
+        selectedTrailingIcon: Icon(YaruIcons.pan_down),
         dropdownMenuEntries: [
           DropdownMenuEntry(value: 1, label: '1'),
           DropdownMenuEntry(value: 2, label: '2'),

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -64,10 +64,12 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     return DecoratedBox(
       decoration: ShapeDecoration(shape: shape.copyWith(side: side)),
       child: Material(
-        color: Colors.transparent,
+        color: style?.backgroundColor?.resolve({}) ?? Colors.transparent,
         clipBehavior: Clip.antiAlias,
         shape: shape,
         child: PopupMenuButton(
+          color: style?.foregroundColor?.resolve({}),
+          iconColor: style?.foregroundColor?.resolve({}),
           enabled: enabled,
           elevation: elevation,
           position: position,
@@ -88,7 +90,8 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
                 padding: padding,
                 child: DefaultTextStyle(
                   style: TextStyle(
-                    color: Theme.of(context).colorScheme.onSurface,
+                    color: style?.foregroundColor?.resolve({}) ??
+                        Theme.of(context).colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                   ),
                   child: Row(
@@ -102,8 +105,9 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
                       SizedBox(
                         height: kYaruTitleBarItemHeight,
                         child: icon ??
-                            const Icon(
+                            Icon(
                               YaruIcons.pan_down,
+                              color: style?.foregroundColor?.resolve({}),
                             ),
                       ),
                     ],


### PR DESCRIPTION
With the example from #774 

Before:
<img width="493" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/e8400a43-be1e-453f-9be1-18c97c92b24b">


After:
<img width="493" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/546f1d62-4e73-492e-bc4a-a289966b3080">


Fixes #774

Bonus: fixed missing icons in the theme page :P 

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
