### PR TITLE
fix(YaruPopupMenuButton): Wrong background color

### DIFF
--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -20,26 +20,7 @@ class _PopupPageState extends State<PopupPage> {
         spacing: 10,
         runSpacing: 10,
         children: [
-          YaruPopupMenuButton<MyEnum>(
-            initialValue: myEnum,
-            onSelected: (v) {
-              setState(() {
-                myEnum = v;
-              });
-            },
-            child: Text(myEnum.name),
-            itemBuilder: (context) {
-              return [
-                for (final value in MyEnum.values)
-                  PopupMenuItem(
-                    value: value,
-                    child: Text(
-                      value.name,
-                    ),
-                  ),
-              ];
-            },
-          ),
+          _buildPopup(),
           YaruPopupMenuButton<MyEnum>(
             onSelected: (value) {
               if (enumSet.contains(value)) {
@@ -79,8 +60,54 @@ class _PopupPageState extends State<PopupPage> {
               ];
             },
           ),
+          Card(
+            child: Column(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: Text('With custom style'),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: _buildPopup(
+                    style: OutlinedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(100),
+                      ),
+                      backgroundColor: YaruColors.prussianGreen,
+                      foregroundColor: Colors.yellow,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
+    );
+  }
+
+  YaruPopupMenuButton<MyEnum> _buildPopup({ButtonStyle? style}) {
+    return YaruPopupMenuButton<MyEnum>(
+      style: style,
+      initialValue: myEnum,
+      onSelected: (v) {
+        setState(() {
+          myEnum = v;
+        });
+      },
+      child: Text(myEnum.name),
+      itemBuilder: (context) {
+        return [
+          for (final value in MyEnum.values)
+            PopupMenuItem(
+              value: value,
+              child: Text(
+                value.name,
+              ),
+            ),
+        ];
+      },
     );
   }
 }

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -68,7 +68,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         shape: shape,
         child: PopupMenuButton(
-          color: style?.foregroundColor?.resolve({}),
+          color: style?.backgroundColor?.resolve({}),
           iconColor: style?.foregroundColor?.resolve({}),
           enabled: enabled,
           elevation: elevation,

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -68,7 +68,6 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         shape: shape,
         child: PopupMenuButton(
-          color: style?.backgroundColor?.resolve({}),
           iconColor: style?.foregroundColor?.resolve({}),
           enabled: enabled,
           elevation: elevation,


### PR DESCRIPTION
|       | Button | Menu |
|-------|--------|-------|
| Light |<img width="491" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/3b16ed5b-16f9-4ecd-baba-a3038c6072d9">|<img width="491" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/7426ee8d-01f1-4338-8d92-d648fdff2f49">|
| Dark  | <img width="491" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/d6332a3d-d28c-4a0e-adef-3138dd0103aa"> |<img width="491" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/5b99da54-dc02-48f2-bcfe-4887460d8eda">|

Fixes #875