### PR TITLE
chore(example): add missing icon

### DIFF
--- a/example/lib/pages/full_color_icons_page.dart
+++ b/example/lib/pages/full_color_icons_page.dart
@@ -228,6 +228,7 @@ const iconDirsToIconNames = <String, Set<String>>{
     'nvidia-settings',
     'org.gnome.Calls',
     'org.gnome.Software.Create',
+    'org.gnome.Software.Develop',
     'org.gnome.Software.Socialize',
     'org.gnome.Software',
     'org.gnome.SoundRecorder',


### PR DESCRIPTION
Now all icons are searched with ls -l | grep -v ^l >> icons.txt, so the list is complete. I started manually in apps when realizing that this is no fun.
Eventually the github dart package can be used to get the names automatically, if it can filter out symlinks. Otherwise it is not really a problem with the bash command.

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
