### PR TITLE
chore(example): improve wording, placement and info

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -60,7 +60,6 @@ class _MasterDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruMasterDetailPage(
-      initialIndex: 1,
       layoutDelegate: const YaruMasterResizablePaneDelegate(
         initialPaneWidth: 280,
         minPageWidth: kYaruMasterDetailBreakpoint / 2,

--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -326,7 +326,7 @@ final examplePageItems = <PageItem>[
         : const Icon(YaruIcons.ubuntu_logo_simple),
   ),
   PageItem(
-    title: 'YaruTheme',
+    title: 'Material Components, using Yaru Material Themes',
     pageBuilder: (context) {
       return const ThemePage();
     },

--- a/example/lib/pages/theme_page/src/controls/chips.dart
+++ b/example/lib/pages/theme_page/src/controls/chips.dart
@@ -12,31 +12,31 @@ class Chips extends StatelessWidget {
       spacing: kWrapSpacing,
       runSpacing: kWrapSpacing,
       children: [
-        const Chip(label: Text('Ch-ch-ch-Chip n Dale')),
+        const Chip(label: Text('Chip')),
         Chip(
           deleteIcon: const Icon(YaruIcons.window_close),
-          label: const Text('Rescue Rangers'),
+          label: const Text('Deletable Chip'),
           onDeleted: () {},
         ),
         const ChoiceChip(
-          label: Text('Ch-ch-ch-Chip n Dale'),
+          label: Text('Disabled Chip'),
           selected: false,
           onSelected: null,
         ),
         ChoiceChip(
-          label: const Text("When there's danger"),
+          label: const Text('Selected ChoiceChip'),
           selected: true,
+          onSelected: (value) {},
+        ),
+        ChoiceChip(
+          label: const Text('ChoiceChip'),
+          selected: false,
           onSelected: (value) {},
         ),
         const ChoiceChip(
-          label: Text('No, no, it never fails'),
+          label: Text('Selected, disabled ChoiceChip'),
           selected: true,
           onSelected: null,
-        ),
-        ChoiceChip(
-          label: const Text('Once they re involved'),
-          selected: false,
-          onSelected: (value) {},
         ),
       ],
     );

--- a/example/lib/pages/theme_page/src/controls/progres.dart
+++ b/example/lib/pages/theme_page/src/controls/progres.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import '../constants.dart';
 
@@ -37,8 +38,17 @@ class _ProgressState extends State<Progress> {
               onChanged: (value) => setState(() => _level = value),
             ),
           ),
+          const Divider(
+            height: 2 * kWrapSpacing,
+          ),
+          const YaruInfoBox(
+            yaruInfoType: YaruInfoType.information,
+            subtitle: Text(
+              'The following material progress indicators are only fallbacks, due to insufficient styling capabilities. Please use YaruLinearProgressIndicator and YaruCircularProgressIndicator instead!',
+            ),
+          ),
           const SizedBox(
-            height: kWrapSpacing,
+            height: 20,
           ),
           Wrap(
             spacing: kWrapSpacing,

--- a/example/lib/pages/theme_page/src/controls/toggleables.dart
+++ b/example/lib/pages/theme_page/src/controls/toggleables.dart
@@ -1,38 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import '../constants.dart';
 
-class Toggleables extends StatefulWidget {
+class Toggleables extends StatelessWidget {
   const Toggleables({super.key});
-
-  @override
-  State<Toggleables> createState() => _ToggleablesState();
-}
-
-class _ToggleablesState extends State<Toggleables> {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      ScaffoldMessenger.of(context).showMaterialBanner(
-        MaterialBanner(
-          content: const Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text(
-              'Info: those are just Fallback toggleables. Please use YaruCheckBox and YaruRadio instead',
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () =>
-                  ScaffoldMessenger.of(context).clearMaterialBanners(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +12,36 @@ class _ToggleablesState extends State<Toggleables> {
       spacing: 10,
       runSpacing: 10,
       children: [
+        Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: [
+            const Text('ToggleButtons:'),
+            ToggleButtons(
+              isSelected: const [true, false, false],
+              onPressed: (v) {},
+              children: const [Text('Off'), Text('Off'), Text('Off')],
+            ),
+            ToggleButtons(
+              isSelected: const [true, false, false],
+              children: const [Text('Off'), Text('Off'), Text('Off')],
+            ),
+            const Divider(
+              height: 2 * kWrapSpacing,
+            ),
+          ],
+        ),
+        const Padding(
+          padding: EdgeInsets.only(
+            bottom: 10,
+          ),
+          child: YaruInfoBox(
+            yaruInfoType: YaruInfoType.information,
+            subtitle: Text(
+              'The following material Checks/Radios are only fallbacks, due to insufficient styling capabilities. Please use YaruCheckBox and YaruRadio instead.',
+            ),
+          ),
+        ),
         Row(
           children: [
             Checkbox(value: true, onChanged: (_) {}),
@@ -79,24 +81,6 @@ class _ToggleablesState extends State<Toggleables> {
             Switch(onChanged: (value) {}, value: false),
             const Switch(value: true, onChanged: null),
             const Switch(value: false, onChanged: null),
-          ],
-        ),
-        Wrap(
-          spacing: 10,
-          runSpacing: 10,
-          children: [
-            ToggleButtons(
-              isSelected: const [true, false, false],
-              onPressed: (v) {},
-              children: const [Text('Off'), Text('Off'), Text('Off')],
-            ),
-            const SizedBox(
-              width: kWrapSpacing,
-            ),
-            ToggleButtons(
-              isSelected: const [true, false, false],
-              children: const [Text('Off'), Text('Off'), Text('Off')],
-            ),
           ],
         ),
       ],

--- a/example/lib/pages/theme_page/src/home/home_page.dart
+++ b/example/lib/pages/theme_page/src/home/home_page.dart
@@ -11,7 +11,7 @@ import '../constants.dart';
 import '../utils.dart';
 import 'color_disk.dart';
 
-final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
+final GlobalKey<ScaffoldState> themePageScaffoldKey = GlobalKey();
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -62,7 +62,7 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      key: _scaffoldKey,
+      key: themePageScaffoldKey,
       drawer: _Drawer(
         selectedIndex: _selectedIndex,
         onSelected: (index) {
@@ -75,7 +75,7 @@ class HomePageState extends State<HomePage> {
         backgroundColor: Colors.transparent,
         leading: Center(
           child: IconButton(
-            onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+            onPressed: () => themePageScaffoldKey.currentState?.openDrawer(),
             icon: const Icon(YaruIcons.menu),
           ),
         ),

--- a/example/lib/pages/theme_page/theme_page.dart
+++ b/example/lib/pages/theme_page/theme_page.dart
@@ -8,14 +8,11 @@ class ThemePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Builder(
-        builder: (context) => YaruTheme(
-          data: AppTheme.of(context),
-          child: const HomePage(),
-        ),
+    return Builder(
+      builder: (context) => YaruTheme(
+        data: AppTheme.of(context),
+        child: const HomePage(),
       ),
-      debugShowCheckedModeBanner: false,
     );
   }
 }


### PR DESCRIPTION
Improved the placement of pages, wording, info and naming for people not involved into yaru yet:

- material components as the first page, as this page has the texttheme and buttons, which is important to see right away
- improved page wording to make it clear that those are pure material components but with Yaru theming
- improved text on/for components where it is not clear what type they are
- added the nice new infoboxes for coponents that have a YaruXXX replacement

<img width="971" alt="Bildschirmfoto 2024-03-10 um 09 26 01" src="https://github.com/ubuntu/yaru.dart/assets/15329494/aeb6e925-c068-476a-b977-ccf76308df97">
<img width="971" alt="Bildschirmfoto 2024-03-10 um 09 26 30" src="https://github.com/ubuntu/yaru.dart/assets/15329494/d937feed-8343-40b7-8e95-520a355ca9d2">
<img width="971" alt="Bildschirmfoto 2024-03-10 um 09 26 45" src="https://github.com/ubuntu/yaru.dart/assets/15329494/87ecbf88-b09e-4e16-86aa-6271a57869a7">
<img width="971" alt="Bildschirmfoto 2024-03-10 um 09 26 57" src="https://github.com/ubuntu/yaru.dart/assets/15329494/295e595e-579a-4f50-8d02-ce55b8896291">
