### PR TITLE
fix(YaruMasterDetailPage): has too many nested Scaffolds

### DIFF
--- a/lib/src/widgets/master_detail/yaru_master_detail_page.dart
+++ b/lib/src/widgets/master_detail/yaru_master_detail_page.dart
@@ -214,8 +214,8 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
     final breakpoint = widget.breakpoint ??
         YaruMasterDetailTheme.of(context).breakpoint ??
         YaruMasterDetailThemeData.fallback(context).breakpoint!;
-    return Scaffold(
-      body: widget.length == 0 || widget.controller?.length == 0
+    return Material(
+      child: widget.length == 0 || widget.controller?.length == 0
           ? widget.emptyBuilder?.call(context) ?? const SizedBox.shrink()
           : _YaruMasterDetailLayoutBuilder(
               breakpoint: breakpoint,


### PR DESCRIPTION
- [X] Test on MacOS
- [X] Test on Linux
- [x] Test on Windows
- [X] Test on Web

![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/dd439689-1eea-4b58-99ff-e052e0780829)
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/3edf5c09-f50a-4c29-a340-fabe7d68227e)
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/21b368f5-46c7-4ea1-ba65-14d765e550f8)

This needs testing on all platforms, as all platforms behave differently with "draw in in the native window" before it can be considered a solution.

Note: in fact no scaffold is needed by default at all, as we only require the next child of materialapp to be a material widget. Scaffold is a very heavy widget with lots of stuff going on there. Even if the "expected" child page of one master element is a Scaffold or a YaruDetailPage, which is a Scaffold with lipstick

The normal layout with YMDP is the following
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/58b3173a-32d9-4bee-83bd-06c7928e4c4a)



Fixes #728
