### PR TITLE
fix: windows window control and titlebar color

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -228,9 +228,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
 
     final closeButton = YaruWindowControl(
       platform: windowControlPlatform,
-      iconColor: windowControlPlatform == YaruWindowControlPlatform.windows
-          ? null
-          : MaterialStatePropertyAll(foregroundColor),
+      iconColor: MaterialStatePropertyAll(foregroundColor),
       type: YaruWindowControlType.close,
       onTap: onClose != null ? () => onClose!(context) : null,
     );

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -257,9 +257,9 @@ class _YaruWindowControlState extends State<YaruWindowControl>
   }
 
   Color _getWindowsIconColor(ColorScheme colorScheme) {
-    var color = widget.iconColor?.resolve(_states) ?? colorScheme.onSurface;
+    final color = widget.iconColor?.resolve(_states) ?? colorScheme.onSurface;
     if (interactive && _hovered && widget.type == YaruWindowControlType.close) {
-      color = Colors.white;
+      return Colors.white;
     }
     return color;
   }

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -244,15 +244,24 @@ class _YaruWindowControlState extends State<YaruWindowControl>
   }
 
   Color _getIconColor(ColorScheme colorScheme) {
-    final iconColor = widget.iconColor?.resolve(_states);
-    if (iconColor != null) return iconColor;
+    final color = switch (style) {
+      YaruWindowControlPlatform.yaru => _getYaruIconColor(colorScheme),
+      YaruWindowControlPlatform.windows => _getWindowsIconColor(colorScheme)
+    };
 
-    switch (style) {
-      case YaruWindowControlPlatform.yaru:
-        return _getYaruIconColor(colorScheme);
-      case YaruWindowControlPlatform.windows:
-        return _getWindowsIconColor(colorScheme);
+    return color.withOpacity(interactive ? 1.0 : 0.5);
+  }
+
+  Color _getYaruIconColor(ColorScheme colorScheme) {
+    return widget.iconColor?.resolve(_states) ?? colorScheme.onSurface;
+  }
+
+  Color _getWindowsIconColor(ColorScheme colorScheme) {
+    var color = widget.iconColor?.resolve(_states) ?? colorScheme.onSurface;
+    if (interactive && _hovered && widget.type == YaruWindowControlType.close) {
+      color = Colors.white;
     }
+    return color;
   }
 
   double get _iconSize {
@@ -262,18 +271,6 @@ class _YaruWindowControlState extends State<YaruWindowControl>
       case YaruWindowControlPlatform.windows:
         return 10.0;
     }
-  }
-
-  Color _getYaruIconColor(ColorScheme colorScheme) {
-    return colorScheme.onSurface.withOpacity(interactive ? 1.0 : 0.5);
-  }
-
-  Color _getWindowsIconColor(ColorScheme colorScheme) {
-    if (_hovered && interactive && widget.type == YaruWindowControlType.close) {
-      return widget.iconColor?.resolve(_states) ?? Colors.white;
-    }
-
-    return colorScheme.onSurface.withOpacity(interactive ? 1.0 : 0.5);
   }
 
   Widget _buildBoxDecoration({


### PR DESCRIPTION
On Windows the titlebar color was not correct in the light mode when overwriting the foreground color via YaruWindowTitleBar the color was not correctly forwarded to the close button

before (Windows):


https://github.com/ubuntu/yaru.dart/assets/15329494/d0027e50-adb2-4776-a854-ac93eb6e9315



after (Windows):


https://github.com/ubuntu/yaru.dart/assets/15329494/2917e02c-5d62-4ab3-b6f3-ec2b4f7fe792


TODO:

- [X] check on Ubuntu

after (Ubuntu) (lol my old intel laptop is dying):

[Bildschirmaufzeichnung vom 2024-04-16, 21-10-12.webm](https://github.com/ubuntu/yaru.dart/assets/15329494/9a884bbb-ad78-458e-89b5-1ad4e1052696)
