### PR TITLE
fix(YaruToggleButton): fix RTL layout

### DIFF
--- a/lib/src/widgets/yaru_toggle_button_layout.dart
+++ b/lib/src/widgets/yaru_toggle_button_layout.dart
@@ -198,9 +198,7 @@ class _YaruRenderToggleButton extends RenderBox
     );
 
     final titleX = leadingSize.width + horizontalSpacing;
-    final textConstraints = constraints
-        .copyWith(maxWidth: constraints.maxWidth - titleX)
-        .normalize();
+    final textConstraints = loosened.tighten(width: availableWidth - titleX);
     final titleSize = _layoutBox(title, textConstraints);
     final subtitleSize = _layoutBox(subtitle, textConstraints);
 


### PR DESCRIPTION
Fix #690 
Related issue: [lp:2064700](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2064700)

I don't quite understand neither the original intention behind those constraints nor the very detailed assertions on the sizes of the render objects in the tests for `YaruToggleButton` (which will all fail for this PR).
This change follows the logic of material's [`ListTile`](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/list_tile.dart#L1370-L1372).

I'll test it more thoroughly next week.