### PR TITLE
fix: use safe picks for ubuntu colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ This repository and package contains:
     yaru_icon_font_generator assets/icons assets/yaru_icons.otf --output-class-file=lib/src/yaru_icons.dart -r
     ```
 
+## Contributing new gtk<->Flutter theme mappings
+
+1. Add a new `YaruVariant` in `variant.dart`
+2. Add a new mapping into the `resolveVariant` method inside `inherited_theme.dart`
+
 # Copying or Reusing
 
 The theme and widgets are licensed under Mozilla Public License Version 2.0.

--- a/lib/src/theme_widgets/inherited_theme.dart
+++ b/lib/src/theme_widgets/inherited_theme.dart
@@ -9,21 +9,14 @@ import 'package:yaru/src/settings.dart';
 import '../../theme.dart';
 
 YaruVariant? _defaultFallBackVariant(Platform platform) {
-  final desktop = !kIsWeb
-      ? platform.environment['XDG_CURRENT_DESKTOP']?.toUpperCase()
-      : null;
-
-  if (desktop != null) {
-    if (platform.isBudgie) return YaruVariant.ubuntuBudgieBlue;
-    if (platform.isCinnamon) return YaruVariant.ubuntuCinnamonBrown;
-    if (platform.isGNOME && platform.isUbuntu) return YaruVariant.orange;
-    if (platform.isGNOME) return YaruVariant.adwaitaBlue;
-    if (platform.isKDE) return YaruVariant.kubuntuBlue;
-    if (platform.isLXQt) return YaruVariant.lubuntuBlue;
-    if (platform.isMATE) return YaruVariant.ubuntuMateGreen;
-    if (platform.isUnity) return YaruVariant.ubuntuUnityPurple;
-    if (platform.isXfce) return YaruVariant.xubuntuBlue;
-  }
+  if (platform.isBudgie) return YaruVariant.ubuntuBudgieBlue;
+  if (platform.isCinnamon) return YaruVariant.ubuntuCinnamonBrown;
+  if (platform.isGNOME) return YaruVariant.orange;
+  if (platform.isKDE) return YaruVariant.kubuntuBlue;
+  if (platform.isLXQt) return YaruVariant.lubuntuBlue;
+  if (platform.isMATE) return YaruVariant.ubuntuMateGreen;
+  if (platform.isUnity) return YaruVariant.ubuntuUnityPurple;
+  if (platform.isXfce) return YaruVariant.xubuntuBlue;
   return null;
 }
 
@@ -190,28 +183,10 @@ class _YaruThemeState extends State<YaruTheme> {
     for (final value in YaruVariant.values) {
       if (value.name.replaceAll('adwaita', '').toLowerCase() ==
           name?.toLowerCase()) {
-        return _mapGnomeColor(value);
+        return value;
       }
     }
     return _defaultFallBackVariant(widget._platform);
-  }
-
-  YaruVariant _mapGnomeColor(YaruVariant variant) {
-    if (widget._platform.isGNOME && widget._platform.isUbuntu) {
-      return variant;
-    }
-    return switch (variant) {
-      YaruVariant.blue => YaruVariant.adwaitaBlue,
-      YaruVariant.red => YaruVariant.adwaitaRed,
-      YaruVariant.orange => YaruVariant.adwaitaOrange,
-      YaruVariant.purple => YaruVariant.adwaitaPurple,
-      YaruVariant.magenta => YaruVariant.adwaitaPink,
-      YaruVariant.prussianGreen ||
-      YaruVariant.ubuntuMateGreen ||
-      YaruVariant.adwaitaSlate =>
-        YaruVariant.adwaitaGreen,
-      _ => variant
-    };
   }
 
   void updateVariant([String? value]) {

--- a/lib/src/theme_widgets/inherited_theme.dart
+++ b/lib/src/theme_widgets/inherited_theme.dart
@@ -166,28 +166,32 @@ class _YaruThemeState extends State<YaruTheme> {
         !widget._platform.environment.containsKey('FLUTTER_TEST');
   }
 
-  final _darkSuffix = '-dark';
-  final _yaruPrefix = 'Yaru-';
-  // "Yaru-prussiangreen-dark" => YaruAccent.prussianGreen
-  YaruVariant? resolveVariant(String? name) {
-    if (name?.endsWith(_darkSuffix) == true) {
-      name = name!.substring(0, name.length - 5);
-    }
-    if (name?.startsWith(_yaruPrefix) == true) {
-      name = name!.substring(_yaruPrefix.length);
-    }
-
-    if (name == 'Yaru') {
-      return YaruVariant.orange;
-    }
-    for (final value in YaruVariant.values) {
-      if (value.name.replaceAll('adwaita', '').toLowerCase() ==
-          name?.toLowerCase()) {
-        return value;
-      }
-    }
-    return _defaultFallBackVariant(widget._platform);
-  }
+  // This very simple but manual solution is the safest approach for now
+  // New theme mappings can be added here easily, after adding them in variant.dart
+  YaruVariant? resolveVariant(String? name) =>
+      switch (name?.replaceAll('-dark', '')) {
+        'Adwaita' => YaruVariant.adwaitaBlue,
+        'Adwaita-green' || 'Yaru-green' => YaruVariant.adwaitaGreen,
+        'Adwaita-orange' => YaruVariant.adwaitaOrange,
+        'Adwaita-pink' || 'Yaru-pink' => YaruVariant.adwaitaPink,
+        'Adwaita-purple' => YaruVariant.adwaitaPurple,
+        'Adwaita-red' => YaruVariant.adwaitaRed,
+        'Adwaita-slate' || 'Yaru-slate' => YaruVariant.adwaitaSlate,
+        'Adwaita-teal' || 'Yaru-teal' => YaruVariant.adwaitaTeal,
+        'Adwaita-yellow' || 'Yaru-yellow' => YaruVariant.adwaitaYellow,
+        'Yaru' => YaruVariant.orange,
+        'Yaru-prussiangreen' => YaruVariant.prussianGreen,
+        'Yaru-bark' => YaruVariant.bark,
+        'Yaru-blue' => YaruVariant.blue,
+        'Yaru-brown' => YaruVariant.brown,
+        'Yaru-magenta' => YaruVariant.magenta,
+        'Yaru-olive' => YaruVariant.olive,
+        'Yaru-purple' => YaruVariant.purple,
+        'Yaru-sage' => YaruVariant.sage,
+        'Yaru-red' => YaruVariant.red,
+        'Yaru-viridian' => YaruVariant.viridian,
+        _ => _defaultFallBackVariant(widget._platform),
+      };
 
   void updateVariant([String? value]) {
     assert(canDetectVariant());


### PR DESCRIPTION
This string kung fu was to unreliable
I changed it to a plain mapping, just replaceAll '-dark' with ''

I tested this for ubuntu ubuntu sessions successfully 


https://github.com/user-attachments/assets/5c74fcdb-bb6d-4604-8bc9-587b9e043910


but it needs to be tested for gnome session too
@3v1n0 

Maybe I manage it in my vm then I will update this PR