### PR TITLE
chore: renamed the snap back to yaru-widgets-example which is what's published

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: yaru-example
+name: yaru-widgets-example
 version: git
 summary: Yaru
 description: Yaru Example
@@ -32,7 +32,7 @@ parts:
       - zip
     override-prime: ''
 
-  yaru-example:
+  yaru-widgets-example:
     after: [ flutter-git ]
     plugin: nil
     source: .
@@ -48,7 +48,7 @@ parts:
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
 
 apps:
-  yaru-example:
+  yaru-widgets-example:
     command: bin/yaru_example
     desktop: snap/gui/yaru-example.desktop
     extensions: [gnome]


### PR DESCRIPTION
Renamed the snap back to yaru-widgets-example which is what's published in the snap store

