### PR TITLE
fix: ensure better contrast for the warty version

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -105,7 +105,8 @@ class YaruColors {
   static const Color sage = Color(0xFF657B69);
 
   /// Warty Brown
-  static const Color wartyBrown = Color(0xFFB39169);
+  /// Actually its  Color(0xFFB39169) but for contrast reassons we use this altered version in Flutter
+  static const Color wartyBrown = Color(0xFF92714a);
 
   /// Prussian Green
   static const Color prussianGreen = Color(0xFF308280);


### PR DESCRIPTION
@3v1n0 only using specific versions of a color only for specific elements is ofc possible but it will probably create some side effects for the moment
So instead could we use your proposed accent color just for all elements instead?
![photo_2024-09-17 21 43 21](https://github.com/user-attachments/assets/1c78cbee-2a88-40df-b055-2152b7aec4c7)
![Bildschirmfoto 2024-09-17 um 21 40 48](https://github.com/user-attachments/assets/34e23c90-b9c4-44d8-8b7f-e86c0b10c3c0)
![Bildschirmfoto 2024-09-17 um 21 40 35](https://github.com/user-attachments/assets/79b9e42c-80f0-4dc1-9ff7-8df01db1f74e)
![Bildschirmfoto 2024-09-17 um 21 40 19](https://github.com/user-attachments/assets/5413dfea-4ac7-42a5-9548-31ea7ed04685)



Fixes #920

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
