### PR TITLE
fix(YaruSplitButton): normal buttons when no option callback

### DIFF
--- a/example/lib/pages/split_button_page.dart
+++ b/example/lib/pages/split_button_page.dart
@@ -77,6 +77,12 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
               menuWidth: width,
               child: const Text('Main Action'),
             ),
+            YaruSplitButton(
+              menuWidth: width,
+              child: const Text('Main Action'),
+              onPressed: () => ScaffoldMessenger.of(context)
+                  .showSnackBar(const SnackBar(content: Text('Main Action'))),
+            ),
           ],
         ),
       ),

--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -56,13 +56,6 @@ class YaruSplitButton extends StatelessWidget {
 
     final defaultRadius = Radius.circular(radius ?? kYaruButtonRadius);
 
-    final mainActionShape = RoundedRectangleBorder(
-      borderRadius: BorderRadius.only(
-        topLeft: defaultRadius,
-        bottomLeft: defaultRadius,
-      ),
-    );
-
     final dropdownShape = switch (_variant) {
       _YaruSplitButtonVariant.outlined => NonUniformRoundedRectangleBorder(
           hideLeftSide: true,
@@ -94,6 +87,15 @@ class YaruSplitButton extends StatelessWidget {
                 )
             : null);
 
+    final mainActionShape = RoundedRectangleBorder(
+      borderRadius: onDropdownPressed == null
+          ? BorderRadius.all(defaultRadius)
+          : BorderRadius.only(
+              topLeft: defaultRadius,
+              bottomLeft: defaultRadius,
+            ),
+    );
+
     final dropdownIcon = icon ?? const Icon(YaruIcons.pan_down);
 
     return Row(
@@ -116,41 +118,42 @@ class YaruSplitButton extends StatelessWidget {
               child: child,
             ),
         },
-        switch (_variant) {
-          _YaruSplitButtonVariant.elevated => ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                fixedSize: size,
-                minimumSize: size,
-                maximumSize: size,
-                padding: dropdownPadding,
-                shape: dropdownShape,
+        if (onDropdownPressed != null)
+          switch (_variant) {
+            _YaruSplitButtonVariant.elevated => ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  fixedSize: size,
+                  minimumSize: size,
+                  maximumSize: size,
+                  padding: dropdownPadding,
+                  shape: dropdownShape,
+                ),
+                onPressed: onDropdownPressed,
+                child: dropdownIcon,
               ),
-              onPressed: onDropdownPressed,
-              child: dropdownIcon,
-            ),
-          _YaruSplitButtonVariant.filled => FilledButton(
-              style: FilledButton.styleFrom(
-                fixedSize: size,
-                minimumSize: size,
-                maximumSize: size,
-                padding: dropdownPadding,
-                shape: dropdownShape,
+            _YaruSplitButtonVariant.filled => FilledButton(
+                style: FilledButton.styleFrom(
+                  fixedSize: size,
+                  minimumSize: size,
+                  maximumSize: size,
+                  padding: dropdownPadding,
+                  shape: dropdownShape,
+                ),
+                onPressed: onDropdownPressed,
+                child: dropdownIcon,
               ),
-              onPressed: onDropdownPressed,
-              child: dropdownIcon,
-            ),
-          _YaruSplitButtonVariant.outlined => OutlinedButton(
-              style: OutlinedButton.styleFrom(
-                fixedSize: size,
-                minimumSize: size,
-                maximumSize: size,
-                padding: dropdownPadding,
-                shape: dropdownShape,
+            _YaruSplitButtonVariant.outlined => OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  fixedSize: size,
+                  minimumSize: size,
+                  maximumSize: size,
+                  padding: dropdownPadding,
+                  shape: dropdownShape,
+                ),
+                onPressed: onDropdownPressed,
+                child: dropdownIcon,
               ),
-              onPressed: onDropdownPressed,
-              child: dropdownIcon,
-            ),
-        },
+          },
       ],
     );
   }


### PR DESCRIPTION

<img width="954" alt="grafik" src="https://github.com/user-attachments/assets/cf3cb784-3c03-44cc-bdcb-ee0a5726e20e">


Ref #912

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
<img width="954" alt="grafik" src="https://github.com/user-attachments/assets/4f728e90-56ca-4e0a-b1d5-20ed08f38ee8">
