### PR TITLE
fix: Correct menu alignment for YaruSplitButton

### DIFF
--- a/example/lib/pages/split_button_page.dart
+++ b/example/lib/pages/split_button_page.dart
@@ -14,6 +14,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
   @override
   Widget build(BuildContext context) {
     const contentWidth = 500.0;
+    const spacing = 16.0;
     final items = List.generate(
       10,
       (index) {
@@ -35,6 +36,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
         title: const Text('YaruSplitButton()'),
         subtitle: const Text('Regular version'),
         trailing: YaruSplitButton(
+          menuWidth: _width,
           onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Main Action')),
           ),
@@ -46,6 +48,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
         title: const Text('YaruSplitButton'),
         subtitle: const Text('.filled()'),
         trailing: YaruSplitButton.filled(
+          menuWidth: _width,
           onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Main Action')),
           ),
@@ -96,6 +99,68 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
         ),
       ),
     ];
+
+    final rows = [
+      Row(
+        children: [
+          const Text('Normal alignment'),
+          const SizedBox(width: spacing),
+          YaruSplitButton.outlined(
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Main Action')),
+            ),
+            items: items.sublist(0, 3),
+            child: const Text('Main Action'),
+          ),
+        ],
+      ),
+      Row(
+        children: [
+          const Text('Normal alignment with width'),
+          const SizedBox(width: spacing),
+          YaruSplitButton.outlined(
+            menuWidth: _width,
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Main Action')),
+            ),
+            items: items.sublist(0, 3),
+            child: const Text('Main Action'),
+          ),
+        ],
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Text('Space between alignment'),
+          const SizedBox(width: spacing),
+          YaruSplitButton.outlined(
+            menuWidth: _width,
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Main Action')),
+            ),
+            items: items.sublist(0, 3),
+            child: const Text('Main Action'),
+          ),
+          const Text('Trailing'),
+        ],
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text('Center alignment'),
+          const SizedBox(width: spacing),
+          YaruSplitButton.outlined(
+            menuWidth: _width,
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Main Action')),
+            ),
+            items: items.sublist(0, 3),
+            child: const Text('Main Action'),
+          ),
+        ],
+      ),
+    ];
+
     final row = Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -116,6 +181,8 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           SizedBox(width: contentWidth, child: row),
+          const SizedBox(height: spacing),
+          const Text('Yaru Tiles'),
           Flexible(
             child: YaruBorderContainer(
               width: contentWidth,
@@ -128,6 +195,25 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
                   child: tiles.elementAt(index),
                 ),
                 separatorBuilder: (context, index) => index != tiles.length - 1
+                    ? const Divider()
+                    : const SizedBox.shrink(),
+              ),
+            ),
+          ),
+          const SizedBox(height: spacing),
+          const Text('Normal rows'),
+          Flexible(
+            child: YaruBorderContainer(
+              width: contentWidth,
+              margin: const EdgeInsets.all(kYaruPagePadding),
+              child: ListView.separated(
+                shrinkWrap: true,
+                itemCount: rows.length,
+                itemBuilder: (context, index) => Padding(
+                  padding: const EdgeInsets.all(5.0),
+                  child: rows.elementAt(index),
+                ),
+                separatorBuilder: (context, index) => index != rows.length - 1
                     ? const Divider()
                     : const SizedBox.shrink(),
               ),

--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -166,7 +166,7 @@ class YaruSplitButton extends StatelessWidget {
     return RelativeRect.fromRect(
       Rect.fromPoints(
         box.localToGlobal(
-          box.size.bottomCenter(offset),
+          box.size.bottomRight(offset),
           ancestor: overlay,
         ),
         box.localToGlobal(


### PR DESCRIPTION
<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
This fixes the issue with the menu alignment, so that the menu is always aligned with the right side of the button.

[Screencast from 2024-10-16 11-32-54.webm](https://github.com/user-attachments/assets/02f31a56-9bc9-411c-88cd-45e02e8c9c68)

@Feichtmeier  If you want I can remove the row examples from the example, I just used them for debugging.