### PR TITLE
fix(YaruPanedView): do not overwrite the divider theme

### DIFF
--- a/lib/src/widgets/yaru_paned_view.dart
+++ b/lib/src/widgets/yaru_paned_view.dart
@@ -140,14 +140,8 @@ class _YaruPanedViewState extends State<YaruPanedView> {
 
   Widget _buildVerticalSeparator() {
     return widget.layoutDelegate.paneSide.isVertical
-        ? const Divider(
-            thickness: 1,
-            height: 1,
-          )
-        : const VerticalDivider(
-            thickness: 1,
-            width: 1,
-          );
+        ? const Divider()
+        : const VerticalDivider();
   }
 
   Widget _buildLeftPaneResizer(


### PR DESCRIPTION
- this should be changed inside the theme

otherwise other dividers to not match the divider inside the yaru paned view, as for example in the app center:
![grafik](https://github.com/user-attachments/assets/9ee657fc-9274-4443-bbab-0f2176939eec)

with this pr the paned view divider used inside the landscape layout is thinner, but most importantly it uses the definition from the theme:

![Bildschirmfoto 2024-10-17 um 15 41 19](https://github.com/user-attachments/assets/74f0f24c-5b62-48fe-8c9b-baac9cccfc44)

