### PR TITLE
fix(Chips): chip height altered by wrong label style, padding at the right

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -660,6 +660,7 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
 ChipThemeData _createChipTheme({
   required Color selectedColor,
   required ColorScheme colorScheme,
+  required TextStyle? textStyle,
 }) {
   final isHC = colorScheme.isHighContrast == true;
   final selectedBackgroundColor =
@@ -669,11 +670,9 @@ ChipThemeData _createChipTheme({
 
   return ChipThemeData(
     selectedColor: selectedBackgroundColor.withOpacity(isHC ? 1 : 0.4),
-    labelStyle: TextStyle(
-      color: colorScheme.onSurface,
-    ),
+    labelStyle: textStyle?.copyWith(color: colorScheme.onSurface),
     checkmarkColor: selectedForeGroundColor,
-    secondaryLabelStyle: TextStyle(
+    secondaryLabelStyle: textStyle?.copyWith(
       color: selectedForeGroundColor,
       fontWeight: isHC ? FontWeight.bold : FontWeight.normal,
     ),
@@ -809,6 +808,7 @@ ThemeData createYaruTheme({
     chipTheme: _createChipTheme(
       selectedColor: elevatedButtonColor ?? colorScheme.primary,
       colorScheme: colorScheme,
+      textStyle: textTheme.bodyMedium,
     ),
   );
 }

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -196,14 +196,15 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
       scrollDirection: Axis.horizontal,
       controller: _controller,
       children: children
-          .map(
-            (e) => Padding(
-              padding: EdgeInsets.only(
-                right: widget.spacing,
-              ),
-              child: e,
-            ),
+          .expand(
+            (item) sync* {
+              yield SizedBox(
+                width: widget.spacing,
+              );
+              yield item;
+            },
           )
+          .skip(1)
           .toList(),
     );
 


### PR DESCRIPTION
The wrong label style made the chips label be placed not in the center 
also in the choice chip bar the padding was always at the end, which is wrong

Before:


https://github.com/user-attachments/assets/9655e8f4-cd34-494e-b25a-c508600ba8a7



After:


https://github.com/user-attachments/assets/96732cca-964d-41df-893d-8248f7bbf301

