### PR TITLE
fix: code snippet button

### DIFF
--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -33,7 +33,7 @@ class CodeSnippedButton extends StatelessWidget {
   }
 }
 
-class _CodeDialog extends StatefulWidget {
+class _CodeDialog extends WatchingWidget {
   const _CodeDialog({
     required this.snippetUrl,
   });
@@ -41,23 +41,11 @@ class _CodeDialog extends StatefulWidget {
   final String snippetUrl;
 
   @override
-  State<_CodeDialog> createState() => _CodeDialogState();
-}
-
-class _CodeDialogState extends State<_CodeDialog> {
-  late Future<String> _snippet;
-
-  @override
-  void initState() {
-    super.initState();
-    _snippet = di<ExampleModel>().getCodeSnippet(
-      widget.snippetUrl,
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
     final appIsOnline = watchPropertyValue((ExampleModel m) => m.appIsOnline);
+    final snippet = di<ExampleModel>().getCodeSnippet(
+      snippetUrl,
+    );
 
     return AlertDialog(
       titlePadding: EdgeInsets.zero,
@@ -70,7 +58,7 @@ class _CodeDialogState extends State<_CodeDialog> {
                   icon: const Icon(YaruIcons.copy),
                   tooltip: 'Copy',
                   onPressed: () async {
-                    await _snippet.then(
+                    await snippet.then(
                       (value) => Clipboard.setData(
                         ClipboardData(text: value),
                       ),
@@ -100,7 +88,7 @@ class _CodeDialogState extends State<_CodeDialog> {
               ),
             )
           : FutureBuilder<String>(
-              future: _snippet,
+              future: snippet,
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {
                   return const Center(
@@ -114,9 +102,7 @@ class _CodeDialogState extends State<_CodeDialog> {
                   child: HighlightView(
                     snapshot.data!,
                     language: 'dart',
-                    theme: Theme.of(context).brightness == Brightness.dark
-                        ? vs2015Theme
-                        : vsTheme,
+                    theme: Theme.of(context).brightness == Brightness.dark ? vs2015Theme : vsTheme,
                     padding: const EdgeInsets.all(12),
                     textStyle: const TextStyle(
                       fontSize: 16,


### PR DESCRIPTION
As i mentioned on the issue #963, 
I tested the online demo, and when attempting to view the code, a grey screen appeared. This typically indicates an error, so I cloned the repository to investigate further. Here's the error I found:

<img width="1769" alt="Screenshot 2024-11-22 at 10 59 36" src="https://github.com/user-attachments/assets/5b886736-a6b6-4f10-8016-c4a90636ffc2">

I worked on fixing it, and I successfully resolved the issue.
The issue lies in the fact that watch_it functions must be called within a WatchingWidget or a WatchingStatefulWidget.

Currently, _CodeDialog is a StatefulWidget, but honestly, if the example relies on watch_it, most StatefulWidget implementations become unnecessary and resource-intensive.

To address this, I converted the widget from a StatefulWidget to a WatchingWidget, and now it works perfectly. 😃 

> Before:
```dart
class _CodeDialog extends StatefulWidget {
  const _CodeDialog({
    required this.snippetUrl,
  });

  final String snippetUrl;

  @override
  State<_CodeDialog> createState() => _CodeDialogState();
}

class _CodeDialogState extends State<_CodeDialog> {
  late Future<String> _snippet;

  @override
  void initState() {
    super.initState();
    _snippet = di<ExampleModel>().getCodeSnippet(
      widget.snippetUrl,
    );
  }
```

After:
```dart
class _CodeDialog extends WatchingWidget {
  const _CodeDialog({
    required this.snippetUrl,
  });

  final String snippetUrl;

  @override
  Widget build(BuildContext context) {
    final appIsOnline = watchPropertyValue((ExampleModel m) => m.appIsOnline);
    final snippet = di<ExampleModel>().getCodeSnippet(
      snippetUrl,
    );

```


<img width="1769" alt="Screenshot 2024-11-22 at 11 03 26" src="https://github.com/user-attachments/assets/88f0cc68-ac01-45b4-b66f-67634cc0a7bb">
