### PR TITLE
feat: reduce YaruInfoBox titleTextStyle default height

### DIFF
--- a/lib/src/widgets/yaru_info.dart
+++ b/lib/src/widgets/yaru_info.dart
@@ -135,7 +135,7 @@ class YaruInfoBox extends StatelessWidget {
   final Color? color;
 
   /// The optional style used for the [DefaultTextStyle] around the [title], defaults to
-  /// `Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold, fontSize: 16.0, height: 1.8)`
+  /// `Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold, fontSize: 16.0, height: 1.3)`
   final TextStyle? titleTextStyle;
 
   /// The optional style used for the [DefaultTextStyle] around the [title], defaults to

--- a/lib/src/widgets/yaru_info.dart
+++ b/lib/src/widgets/yaru_info.dart
@@ -169,12 +169,12 @@ class YaruInfoBox extends StatelessWidget {
                           theme.textTheme.headlineSmall?.copyWith(
                             fontWeight: FontWeight.bold,
                             fontSize: 16.0,
-                            height: 1.8,
+                            height: 1.3,
                           ) ??
                           TextStyle(
                             fontWeight: FontWeight.bold,
                             fontSize: 16.0,
-                            height: 1.8,
+                            height: 1.3,
                             color: theme.colorScheme.onSurface,
                           ),
                       child: title!,


### PR DESCRIPTION
Hi @Feichtmeier :slightly_smiling_face: 

While making use of the `YaruInfoBox`, @juanruitina and I found the default value for `height` for the `titleTextStyle` was a bit high and lead to the text wrapping leaving more space between the two lines of the wrapped title text than between the title and the subtitle:
![Screenshot From 2025-03-13 12-59-14](https://github.com/user-attachments/assets/23d9195c-760b-42ce-9d0c-7581294194d1)

After some playing around with values, 1.3 seems to get better results:

![Screenshot From 2025-03-13 17-46-50](https://github.com/user-attachments/assets/f9011818-74b5-47fa-b795-2b237deeea06)

We currently are just overriding the style on the title, but thought it would be valuable to upstream as a default. 

