### PR TITLE
fix: YaruExpandable: handle tap on header background

### DIFF
--- a/lib/src/widgets/yaru_expandable.dart
+++ b/lib/src/widgets/yaru_expandable.dart
@@ -95,9 +95,7 @@ class _YaruExpandableState extends State<YaruExpandable> {
       ),
     );
 
-    final header = Flexible(
-      child: GestureDetector(onTap: _onTap, child: widget.header),
-    );
+    final header = Flexible(child: widget.header);
 
     final MainAxisAlignment expandButtonPosition;
     final List<Widget> headerChildren;
@@ -115,9 +113,13 @@ class _YaruExpandableState extends State<YaruExpandable> {
 
     return Column(
       children: [
-        Row(
-          mainAxisAlignment: expandButtonPosition,
-          children: headerChildren,
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _onTap,
+          child: Row(
+            mainAxisAlignment: expandButtonPosition,
+            children: headerChildren,
+          ),
         ),
         AnimatedCrossFade(
           firstChild: _buildChild(widget.child),

--- a/test/widgets/yaru_expandable_test.dart
+++ b/test/widgets/yaru_expandable_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaru/src/widgets/yaru_expandable.dart';
+import 'package:yaru/src/widgets/yaru_icon_button.dart';
+
+const kHeaderText = 'Lorem ipsum dolor sit amet';
+const kContentText =
+    'Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+void main() {
+  testWidgets('icon is tappable', (tester) async {
+    var isExpanded = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: YaruExpandable(
+            isExpanded: isExpanded,
+            onChange: (value) => isExpanded = value,
+            header: const Text(kHeaderText),
+            child: const Text(kContentText),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(YaruExpandable), findsOneWidget);
+    expect(find.byType(YaruIconButton), findsOneWidget);
+    expect(find.text(kHeaderText), findsOneWidget);
+    expect(isExpanded, isFalse);
+
+    await tester.tap(find.byType(YaruIconButton));
+    await tester.pumpAndSettle();
+    expect(isExpanded, isTrue);
+
+    await tester.tap(find.byType(YaruIconButton));
+    await tester.pumpAndSettle();
+    expect(isExpanded, isFalse);
+  });
+
+  testWidgets('header text is tappable', (tester) async {
+    var isExpanded = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: YaruExpandable(
+            isExpanded: isExpanded,
+            onChange: (value) => isExpanded = value,
+            header: const Text(kHeaderText),
+            child: const Text(kContentText),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(YaruExpandable), findsOneWidget);
+    expect(find.byType(YaruIconButton), findsOneWidget);
+    expect(find.text(kHeaderText), findsOneWidget);
+    expect(isExpanded, isFalse);
+
+    await tester.tap(find.text(kHeaderText));
+    await tester.pumpAndSettle();
+    expect(isExpanded, isTrue);
+
+    await tester.tap(find.text(kHeaderText));
+    await tester.pumpAndSettle();
+    expect(isExpanded, isFalse);
+  });
+
+  testWidgets('header background is tappable', (tester) async {
+    var isExpanded = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: YaruExpandable(
+            isExpanded: isExpanded,
+            onChange: (value) => isExpanded = value,
+            header: const Text(kHeaderText),
+            child: const Text(kContentText),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(YaruExpandable), findsOneWidget);
+    expect(find.byType(YaruIconButton), findsOneWidget);
+    expect(find.text(kHeaderText), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text(kHeaderText),
+        matching: find.byType(GestureDetector),
+      ),
+      findsOneWidget,
+    );
+    expect(isExpanded, isFalse);
+
+    await tester.tap(
+      find.ancestor(
+        of: find.text(kHeaderText),
+        matching: find.byType(GestureDetector),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(isExpanded, isTrue);
+
+    await tester.tap(
+      find.ancestor(
+        of: find.text(kHeaderText),
+        matching: find.byType(GestureDetector),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(isExpanded, isFalse);
+  });
+}


### PR DESCRIPTION
A proposal to allow expanding and collapsing `YaruExpandable` and `YaruExpansionPanel` by tapping anywhere on the header, not just the header child and the icon button.

The interactive area visualized before vs. after:

| Before | After |
|--------|-------|
| ![Screenshot From 2025-03-19 15-17-19](https://github.com/user-attachments/assets/df7f4bbc-7874-4cf9-9fb8-5a5fdcdc74ae) | ![Screenshot From 2025-03-19 15-14-08](https://github.com/user-attachments/assets/2a4a23eb-2101-44c4-b7e7-f5ad217c6531) |

This small behavioral change makes a big difference, especially on the accessibility page in the desktop installer (before, clicking where the cursor is would do nothing):

![image](https://github.com/user-attachments/assets/781e282c-f864-4057-9629-653e0405999b)