### PR TITLE
fix: YaruWindowTitleBar double-tap on macOS

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -40,6 +40,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     this.isRestorable,
     this.onClose,
     this.onDrag,
+    this.onDoubleTap,
     this.onMaximize,
     this.onMinimize,
     this.onRestore,
@@ -103,6 +104,9 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
 
   /// Called when the title bar is dragged to move the window.
   final FutureOr<void> Function(BuildContext)? onDrag;
+
+  /// Called when the title bar is double-tapped.
+  final FutureOr<void> Function(BuildContext)? onDoubleTap;
 
   /// Called when the maximize button is pressed or the title bar is
   /// double-clicked while the window is not maximized.
@@ -235,11 +239,13 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     return TextFieldTapRegion(
       child: YaruTitleBarGestureDetector(
         onDrag: isDraggable == true ? (_) => onDrag?.call(context) : null,
-        onDoubleTap: () => isMaximizable == true
-            ? onMaximize?.call(context)
-            : isRestorable == true
-                ? onRestore?.call(context)
-                : null,
+        onDoubleTap: () => onDoubleTap != null
+            ? onDoubleTap!(context)
+            : isMaximizable == true
+                ? onMaximize?.call(context)
+                : isRestorable == true
+                    ? onRestore?.call(context)
+                    : null,
         onSecondaryTap: onShowMenu != null ? () => onShowMenu!(context) : null,
         child: AppBar(
           elevation: titleBarTheme.elevation,
@@ -584,6 +590,13 @@ class YaruWindowTitleBar extends StatelessWidget
               isRestorable ?? state?.isRestorable?.exceptMacOS(context),
           onClose: onClose,
           onDrag: onDrag,
+          onDoubleTap: (context) {
+            if (isMaximizable ?? state?.isMaximizable == true) {
+              onMaximize?.call(context);
+            } else if (isRestorable ?? state?.isRestorable == true) {
+              onRestore?.call(context);
+            }
+          },
           onMaximize: onMaximize,
           onMinimize: onMinimize,
           onRestore: onRestore,


### PR DESCRIPTION
Brought up in #984.

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
