### PR TITLE
fix!: remove isMobile getter and do not change theme if on mobile

### DIFF
--- a/example/lib/pages/theme_page/src/home/home_page.dart
+++ b/example/lib/pages/theme_page/src/home/home_page.dart
@@ -102,10 +102,9 @@ class MaterialThemeHomePageState extends State<MaterialThemeHomePage> {
                   onDestinationSelected: (index) =>
                       setState(() => _selectedIndex = index),
                 ),
-                if (!isMobile)
-                  const VerticalDivider(
-                    width: 0.0,
-                  ),
+                const VerticalDivider(
+                  width: 0.0,
+                ),
                 Expanded(
                   child: Center(
                     child: _items.entries.elementAt(_selectedIndex).key,
@@ -121,10 +120,9 @@ class MaterialThemeHomePageState extends State<MaterialThemeHomePage> {
                     child: _items.entries.elementAt(_selectedIndex).key,
                   ),
                 ),
-                if (!isMobile)
-                  const Divider(
-                    height: 0.0,
-                  ),
+                const Divider(
+                  height: 0.0,
+                ),
                 NavigationBar(
                   destinations: [
                     for (final item in _items.entries)

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -1,15 +1,9 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:yaru/constants.dart';
 import 'package:yaru/theme.dart';
 
 import 'text_theme.dart';
-
-bool get isMobile =>
-    !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isFuchsia);
 
 // AppBar
 
@@ -711,21 +705,6 @@ ThemeData createYaruTheme({
       ? colorScheme.outlineVariant
       : colorScheme.outline.scale(lightness: colorScheme.isLight ? 0.1 : -0.06);
   final textTheme = createTextTheme(colorScheme.onSurface);
-
-  if (isMobile) {
-    return ThemeData(
-      textTheme: textTheme,
-      dividerColor: dividerColor,
-      scaffoldBackgroundColor: colorScheme.surface,
-      dividerTheme: DividerThemeData(
-        color: dividerColor,
-        space: 1.0,
-        thickness: 1.0,
-      ),
-      useMaterial3: true,
-      colorScheme: colorScheme,
-    );
-  }
 
   final themeData = ThemeData.from(
     useMaterial3: useMaterial3,


### PR DESCRIPTION
Remove the isMobile flag as this shouldnt be in a theme library at all.
This is app specific behaviour. This is a breaking change as this removes a getter which might be used by some app.

Also returning an empty material theme also has no use because people can just switch the themes on their own. Alternatively we could provide other createYaruBig (or something) themes for bigger buttons or paramterize the existing functions.

(general notice, only needs one reviewer, so I add a bunch to get someone who is online right now :) and all of you are capable of reviewing yaru.dart)