### PR TITLE
feat(a11y): Add optional semantic label for expandable icon

### DIFF
--- a/lib/src/widgets/yaru_expandable.dart
+++ b/lib/src/widgets/yaru_expandable.dart
@@ -20,6 +20,7 @@ class YaruExpandable extends StatefulWidget {
     required this.header,
     this.expandIcon,
     this.expandIconPadding = EdgeInsets.zero,
+    this.expandIconSemanticLabel,
     this.expandButtonPosition = YaruExpandableButtonPosition.end,
     required this.child,
     this.collapsedChild,
@@ -38,6 +39,9 @@ class YaruExpandable extends StatefulWidget {
 
   /// Optional padding around the expand button.
   final EdgeInsetsGeometry expandIconPadding;
+
+  /// Optional semantic label to add to the expand button.
+  final String? expandIconSemanticLabel;
 
   /// Controls expand button position, see [YaruExpandableButtonPosition].
   final YaruExpandableButtonPosition expandButtonPosition;
@@ -90,7 +94,12 @@ class _YaruExpandableState extends State<YaruExpandable> {
           turns: _isExpanded ? .25 : 0,
           duration: _kAnimationDuration,
           curve: _kAnimationCurve,
-          child: widget.expandIcon ?? const Icon(YaruIcons.pan_end),
+          child:
+              widget.expandIcon ??
+              Icon(
+                YaruIcons.pan_end,
+                semanticLabel: widget.expandIconSemanticLabel,
+              ),
         ),
       ),
     );


### PR DESCRIPTION
Adds an optional string to be used as the semantic label for the expandable icon.

This may or may not be desirable since a custom `Icon` can already be provided, but for example in the App Center, we want to use the icon provided by `YaruExpandable`, but with a more accessible label.

Obviously, if surfacing semantics for this widget is determined to be the path forward, then I'd imagine all icon buttons should surface such options at some point.
