### PR TITLE
feat(a11y): Add field for a semantic label for all icon buttons

### DIFF
--- a/lib/src/widgets/yaru_back_button.dart
+++ b/lib/src/widgets/yaru_back_button.dart
@@ -7,7 +7,13 @@ import 'yaru_icon_button.dart';
 /// A Yaru style back button.
 class YaruBackButton extends StatelessWidget {
   /// Creates a [YaruBackButton].
-  const YaruBackButton({super.key, this.onPressed, this.style, this.icon});
+  const YaruBackButton({
+    super.key,
+    this.onPressed,
+    this.style,
+    this.icon,
+    this.semanticLabel,
+  });
 
   /// An optional callback that is called when the button is pressed.
   ///
@@ -22,13 +28,16 @@ class YaruBackButton extends StatelessWidget {
   /// Defaults to `const Icon(YaruIcons.go_previous)`
   final Widget? icon;
 
+  /// Optional semantic label to add to the back button icon.
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
     final theme = YaruBackButtonTheme.of(context);
     final round = (style ?? theme?.style) == YaruBackButtonStyle.rounded;
     final shape = round ? const CircleBorder() : const BeveledRectangleBorder();
     final button = YaruIconButton(
-      icon: icon ?? const Icon(YaruIcons.go_previous),
+      icon: icon ?? Icon(YaruIcons.go_previous, semanticLabel: semanticLabel),
       tooltip: MaterialLocalizations.of(context).backButtonTooltip,
       style: ButtonStyle(shape: ButtonStyleButton.allOrNull(shape)),
       onPressed: () {

--- a/lib/src/widgets/yaru_carousel.dart
+++ b/lib/src/widgets/yaru_carousel.dart
@@ -26,6 +26,8 @@ class YaruCarousel extends StatefulWidget {
     this.navigationControls = false,
     this.previousIcon,
     this.nextIcon,
+    this.previousIconSemanticLabel,
+    this.nextIconSemanticLabel,
   });
 
   /// The height of the children, defaults to 500.0.
@@ -60,6 +62,12 @@ class YaruCarousel extends StatefulWidget {
   /// Icon used for the next button.
   /// Require [navigationControls] to be true.
   final Widget? nextIcon;
+
+  /// Optional semantic label to add to the previous button icon.
+  final String? previousIconSemanticLabel;
+
+  /// Optional semantic label to add to the next button icon.
+  final String? nextIconSemanticLabel;
 
   @override
   State<YaruCarousel> createState() => _YaruCarouselState();
@@ -165,12 +173,20 @@ class _YaruCarouselState extends State<YaruCarousel> {
             _buildNavigationButton(
               Alignment.centerLeft,
               _isFirstPage() ? null : _controller.previousPage,
-              widget.previousIcon ?? const Icon(YaruIcons.go_previous),
+              widget.previousIcon ??
+                  Icon(
+                    YaruIcons.go_previous,
+                    semanticLabel: widget.previousIconSemanticLabel,
+                  ),
             ),
             _buildNavigationButton(
               Alignment.centerRight,
               _isLastPage() ? null : _controller.nextPage,
-              widget.nextIcon ?? const Icon(YaruIcons.go_next),
+              widget.nextIcon ??
+                  Icon(
+                    YaruIcons.go_next,
+                    semanticLabel: widget.nextIconSemanticLabel,
+                  ),
             ),
           ],
         ),

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -26,6 +26,8 @@ class YaruChoiceChipBar extends StatefulWidget {
     this.wrapTextDirection,
     this.goPreviousIcon,
     this.goNextIcon,
+    this.goPreviousIconSemanticLabel,
+    this.goNextIconSemanticLabel,
     this.clearOnSelect = true,
     this.shrinkWrap = true,
     this.showCheckMarks = true,
@@ -102,6 +104,12 @@ class YaruChoiceChipBar extends StatefulWidget {
 
   /// The [Widget] shown inside the right navigation button.
   final Widget? goNextIcon;
+
+  /// Optional semantic label to add to the previous button icon.
+  final String? goPreviousIconSemanticLabel;
+
+  /// Optional semantic label to add to the next button icon.
+  final String? goNextIconSemanticLabel;
 
   /// Flag to select if the scroll view should to back to the start on selection.
   /// Defaults to `true`.
@@ -207,7 +215,12 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
     final goPreviousButton = _NavigationButton(
       elevation: widget.navigationButtonElevation,
       chipHeight: widget.chipHeight,
-      icon: widget.goPreviousIcon ?? const Icon(YaruIcons.go_previous),
+      icon:
+          widget.goPreviousIcon ??
+          Icon(
+            YaruIcons.go_previous,
+            semanticLabel: widget.goPreviousIconSemanticLabel,
+          ),
       onTap: _enableGoPreviousButton
           ? () => _controller.animateTo(
               _controller.position.pixels - widget.navigationStep,
@@ -220,7 +233,12 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
     final goNextButton = _NavigationButton(
       elevation: widget.navigationButtonElevation,
       chipHeight: widget.chipHeight,
-      icon: widget.goNextIcon ?? const Icon(YaruIcons.go_next),
+      icon:
+          widget.goNextIcon ??
+          Icon(
+            YaruIcons.go_next,
+            semanticLabel: widget.goNextIconSemanticLabel,
+          ),
       onTap: _enableGoNextButton
           ? () => _controller.animateTo(
               _controller.position.pixels + widget.navigationStep,

--- a/lib/src/widgets/yaru_close_button.dart
+++ b/lib/src/widgets/yaru_close_button.dart
@@ -12,12 +12,14 @@ class YaruCloseButton extends StatelessWidget {
     this.onPressed,
     this.alignment = Alignment.center,
     this.icon,
+    this.semanticLabel,
   });
 
   final bool enabled;
   final VoidCallback? onPressed;
   final AlignmentGeometry alignment;
   final Widget? icon;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +28,8 @@ class YaruCloseButton extends StatelessWidget {
       child: YaruIconButton(
         padding: EdgeInsets.zero,
         onPressed: enabled ? onPressed ?? Navigator.of(context).maybePop : null,
-        icon: icon ?? const Icon(YaruIcons.window_close),
+        icon:
+            icon ?? Icon(YaruIcons.window_close, semanticLabel: semanticLabel),
         iconSize: _kCloseButtonSize,
       ),
     );

--- a/lib/src/widgets/yaru_date_time_entry.dart
+++ b/lib/src/widgets/yaru_date_time_entry.dart
@@ -51,6 +51,7 @@ class YaruDateTimeEntry extends _YaruDateTimeEntry {
     super.errorInvalidText,
     super.autofocus = false,
     super.acceptEmpty = true,
+    super.clearIconSemanticLabel,
   }) : super(
          controller: controller,
          type: includeTime
@@ -95,6 +96,7 @@ class YaruTimeEntry extends StatelessWidget {
     this.errorInvalidText,
     this.autofocus,
     this.acceptEmpty,
+    this.clearIconSemanticLabel,
   });
 
   /// A controller that can retrieve parsed [TimeOfDay] from the input and modify its value.
@@ -149,6 +151,9 @@ class YaruTimeEntry extends StatelessWidget {
   /// If true, [errorFormatText] is not shown when the date input field is empty.
   final bool? acceptEmpty;
 
+  /// Optional semantic label to add to the clear button icon.
+  final String? clearIconSemanticLabel;
+
   static ValueChanged<DateTime?>? _valueChangedCallbackAdapter(
     ValueChanged<TimeOfDay?>? callback,
   ) {
@@ -185,6 +190,7 @@ class YaruTimeEntry extends StatelessWidget {
       autofocus: autofocus,
       acceptEmpty: acceptEmpty,
       type: _YaruDateTimeEntryType.time,
+      clearIconSemanticLabel: clearIconSemanticLabel,
     );
   }
 }
@@ -216,6 +222,7 @@ class _YaruDateTimeEntry extends StatefulWidget {
     this.errorInvalidText,
     this.autofocus,
     this.acceptEmpty,
+    this.clearIconSemanticLabel,
   }) : assert(initialDateTime == null || controller == null),
        assert((initialDateTime == null) != (controller == null));
 
@@ -273,6 +280,9 @@ class _YaruDateTimeEntry extends StatefulWidget {
   ///
   /// If null, defaults to true.
   final bool? acceptEmpty;
+
+  /// Optional semantic label to add to the clear button icon.
+  final String? clearIconSemanticLabel;
 
   @override
   State<_YaruDateTimeEntry> createState() => YaruDateTimeEntryState();
@@ -704,7 +714,10 @@ class YaruDateTimeEntryState extends State<_YaruDateTimeEntry> {
 
         _onChanged();
       },
-      icon: const Icon(YaruIcons.edit_clear),
+      icon: Icon(
+        YaruIcons.edit_clear,
+        semanticLabel: widget.clearIconSemanticLabel,
+      ),
     );
   }
 

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -26,6 +26,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.style,
     this.mouseCursor,
     this.icon,
+    this.semanticLabel,
   });
 
   final T? initialValue;
@@ -45,6 +46,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final ButtonStyle? style;
   final MouseCursor? mouseCursor;
   final Widget? icon;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +107,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
                             Icon(
                               YaruIcons.pan_down,
                               color: style?.foregroundColor?.resolve({}),
+                              semanticLabel: semanticLabel,
                             ),
                       ),
                     ],

--- a/lib/src/widgets/yaru_search_field.dart
+++ b/lib/src/widgets/yaru_search_field.dart
@@ -30,6 +30,7 @@ class YaruSearchField extends StatefulWidget {
     this.controller,
     this.focusNode,
     this.clearIcon,
+    this.clearIconSemanticLabel,
   });
 
   /// Optional [String] forwarded to the internal [TextEditingController]
@@ -78,6 +79,9 @@ class YaruSearchField extends StatefulWidget {
 
   /// Optional icon shown inside the clear button.
   final Widget? clearIcon;
+
+  /// Optional semantic label to add to the clear button icon.
+  final String? clearIconSemanticLabel;
 
   @override
   State<YaruSearchField> createState() => _YaruSearchFieldState();
@@ -193,7 +197,11 @@ class _YaruSearchFieldState extends State<YaruSearchField> {
                     icon: ClipRRect(
                       borderRadius: suffixRadius,
                       child:
-                          widget.clearIcon ?? const Icon(YaruIcons.edit_clear),
+                          widget.clearIcon ??
+                          Icon(
+                            YaruIcons.edit_clear,
+                            semanticLabel: widget.clearIconSemanticLabel,
+                          ),
                     ),
                   ),
           ),
@@ -349,6 +357,7 @@ class YaruSearchButton extends StatelessWidget {
     this.borderColor,
     this.icon,
     this.selectedIcon,
+    this.semanticLabel,
   });
 
   final bool? searchActive;
@@ -359,6 +368,7 @@ class YaruSearchButton extends StatelessWidget {
   final Color? borderColor;
   final Widget? icon;
   final Widget? selectedIcon;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -396,6 +406,7 @@ class YaruSearchButton extends StatelessWidget {
                 //
                 size: kYaruIconSize - 4,
                 color: theme.colorScheme.onSurface,
+                semanticLabel: semanticLabel,
               ),
           icon:
               icon ??
@@ -403,6 +414,7 @@ class YaruSearchButton extends StatelessWidget {
                 YaruIcons.search,
                 size: kYaruIconSize - 4,
                 color: theme.colorScheme.onSurface,
+                semanticLabel: semanticLabel,
               ),
           onPressed: onPressed,
         ),

--- a/lib/src/widgets/yaru_search_field.dart
+++ b/lib/src/widgets/yaru_search_field.dart
@@ -358,6 +358,7 @@ class YaruSearchButton extends StatelessWidget {
     this.icon,
     this.selectedIcon,
     this.semanticLabel,
+    this.selectedSemanticLabel,
   });
 
   final bool? searchActive;
@@ -369,6 +370,7 @@ class YaruSearchButton extends StatelessWidget {
   final Widget? icon;
   final Widget? selectedIcon;
   final String? semanticLabel;
+  final String? selectedSemanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -406,7 +408,7 @@ class YaruSearchButton extends StatelessWidget {
                 //
                 size: kYaruIconSize - 4,
                 color: theme.colorScheme.onSurface,
-                semanticLabel: semanticLabel,
+                semanticLabel: selectedSemanticLabel,
               ),
           icon:
               icon ??

--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -12,6 +12,7 @@ class YaruSplitButton extends StatelessWidget {
     this.child,
     this.onOptionsPressed,
     this.icon,
+    this.iconSemanticLabel,
     this.radius,
     this.menuWidth,
   }) : _variant = _YaruSplitButtonVariant.elevated;
@@ -23,6 +24,7 @@ class YaruSplitButton extends StatelessWidget {
     this.child,
     this.onOptionsPressed,
     this.icon,
+    this.iconSemanticLabel,
     this.radius,
     this.menuWidth,
   }) : _variant = _YaruSplitButtonVariant.filled;
@@ -34,6 +36,7 @@ class YaruSplitButton extends StatelessWidget {
     this.child,
     this.onOptionsPressed,
     this.icon,
+    this.iconSemanticLabel,
     this.radius,
     this.menuWidth,
   }) : _variant = _YaruSplitButtonVariant.outlined;
@@ -43,6 +46,7 @@ class YaruSplitButton extends StatelessWidget {
   final void Function()? onOptionsPressed;
   final Widget? child;
   final Widget? icon;
+  final String? iconSemanticLabel;
   final List<PopupMenuEntry<Object?>>? items;
   final double? radius;
   final double? menuWidth;
@@ -95,7 +99,8 @@ class YaruSplitButton extends StatelessWidget {
             ),
     );
 
-    final dropdownIcon = icon ?? const Icon(YaruIcons.pan_down);
+    final dropdownIcon =
+        icon ?? Icon(YaruIcons.pan_down, semanticLabel: iconSemanticLabel);
 
     return Row(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Adds the option to specify a semantic label for all icon buttons (hopefully I got them all, let me know if I missed some :)). As stated in https://github.com/ubuntu/yaru.dart/pull/999, this is useful since it allows `yaru.dart` users to retain the Yaru style and icons while providing more accessible labels to buttons.

This is a non-breaking change, it only adds an optional field to widgets that use icon buttons.