### PR TITLE
fix(YaruChoiceChipBar): do not always show scroll buttons on init

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   FLUTTER_VERSION: 3.32.0

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -125,7 +125,7 @@ class YaruChoiceChipBar extends StatefulWidget {
 class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
   late ScrollController _controller;
   bool _enableGoPreviousButton = false;
-  bool _enableGoNextButton = true;
+  bool _enableGoNextButton = false;
 
   @override
   void initState() {


### PR DESCRIPTION
In YaruChoiceChipBar the go next button was always shown in the stacked style. This fixes it.