### PR TITLE
fix: use consistent text styles in `InputDecorationTheme`

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -107,6 +107,7 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
       bottom: 9,
       top: 10,
     ),
+    errorStyle: textStyle,
     helperStyle: textStyle,
     hintStyle: textStyle,
     labelStyle: textStyle,


### PR DESCRIPTION
Fix #1004 