### PR TITLE
fix(a11y): Fix semantics being discarded for each Navigator

### DIFF
--- a/lib/src/widgets/master_detail/yaru_landscape_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_landscape_layout.dart
@@ -133,25 +133,29 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
         context,
       ).copyWith(pageTransitionsTheme: theme.landscapeTransitions),
       child: ScaffoldMessenger(
-        child: Navigator(
-          key: widget.navigatorKey,
-          initialRoute: widget.initialRoute,
-          onGenerateRoute: widget.onGenerateRoute,
-          onUnknownRoute: widget.onUnknownRoute,
-          pages: [
-            MaterialPage(
-              key: ValueKey(_selectedIndex),
-              child: Builder(
-                builder: (context) => widget.controller.length > _selectedIndex
-                    ? widget.pageBuilder(context, _selectedIndex)
-                    : widget.pageBuilder(context, 0),
+        child: Semantics(
+          container: true,
+          child: Navigator(
+            key: widget.navigatorKey,
+            initialRoute: widget.initialRoute,
+            onGenerateRoute: widget.onGenerateRoute,
+            onUnknownRoute: widget.onUnknownRoute,
+            pages: [
+              MaterialPage(
+                key: ValueKey(_selectedIndex),
+                child: Builder(
+                  builder: (context) =>
+                      widget.controller.length > _selectedIndex
+                      ? widget.pageBuilder(context, _selectedIndex)
+                      : widget.pageBuilder(context, 0),
+                ),
               ),
-            ),
-          ],
-          // TODO: implement replacement if we keep YaruMasterDetailPage
-          // ignore: deprecated_member_use
-          onPopPage: (route, result) => route.didPop(result),
-          observers: [...widget.navigatorObservers, HeroController()],
+            ],
+            // TODO: implement replacement if we keep YaruMasterDetailPage
+            // ignore: deprecated_member_use
+            onPopPage: (route, result) => route.didPop(result),
+            observers: [...widget.navigatorObservers, HeroController()],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
The `YaruMasterDetailPage` has an issue where the left navigation buttons are invisible to screen readers. For example, if you wrap the `ExampleHome` app in `SemanticsDebugger` you can see the button labels are not present:

![image](https://github.com/user-attachments/assets/c8a3a96f-36dc-4c07-bf5d-1cac6ddb03c5)

This PR uses [this suggestion](https://github.com/flutter/flutter/issues/55758#issuecomment-620920637) from a Flutter issue describing this problem as a problem with the `Navigator` and how it builds routes. Now, the semantics look like this:

![image](https://github.com/user-attachments/assets/1e9f8125-3653-4075-98d1-73acbb790016)

I've tested this with both the example app provided by this library and the [App Center](https://github.com/ubuntu/app-center), and it fixes both apps while retaining the same functionality.

Fixes https://github.com/ubuntu/yaru.dart/issues/997