### PR TITLE
feat(a11y): Expose semantic label options for window controls

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -49,6 +49,10 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     this.platform,
     this.buttonPadding,
     this.buttonSpacing,
+    this.closeSemanticLabel,
+    this.maximizeSemanticLabel,
+    this.minimizeSemanticLabel,
+    this.restoreSemanticLabel,
   });
 
   /// The primary title widget.
@@ -121,6 +125,18 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
 
   /// Called when the secondary mouse button is pressed.
   final FutureOr<void> Function(BuildContext)? onShowMenu;
+
+  /// Semantic label used for the close button.
+  final String? closeSemanticLabel;
+
+  /// Semantic label used for the maximize button.
+  final String? maximizeSemanticLabel;
+
+  /// Semantic label used for the minimize button.
+  final String? minimizeSemanticLabel;
+
+  /// Semantic label used for the restore button.
+  final String? restoreSemanticLabel;
 
   /// The tag to use for the [Hero] wrapping the window controls.
   ///
@@ -232,6 +248,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
       iconColor: WidgetStatePropertyAll(foregroundColor),
       type: YaruWindowControlType.close,
       onTap: onClose != null ? () => onClose!(context) : null,
+      semanticLabel: closeSemanticLabel,
     );
     return TextFieldTapRegion(
       child: YaruTitleBarGestureDetector(
@@ -282,6 +299,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                                 onTap: onMinimize != null
                                     ? () => onMinimize!(context)
                                     : null,
+                                semanticLabel: minimizeSemanticLabel,
                               ),
                             if (isRestorable == true)
                               YaruWindowControl(
@@ -293,6 +311,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                                 onTap: onRestore != null
                                     ? () => onRestore!(context)
                                     : null,
+                                semanticLabel: restoreSemanticLabel,
                               ),
                             if (isMaximizable == true)
                               YaruWindowControl(
@@ -304,6 +323,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                                 onTap: onMaximize != null
                                     ? () => onMaximize!(context)
                                     : null,
+                                semanticLabel: maximizeSemanticLabel,
                               ),
                             if (isClosable == true)
                               isMaximizable == true
@@ -455,6 +475,10 @@ class YaruWindowTitleBar extends StatelessWidget
     this.platform,
     this.buttonPadding,
     this.buttonSpacing,
+    this.closeSemanticLabel,
+    this.maximizeSemanticLabel,
+    this.minimizeSemanticLabel,
+    this.restoreSemanticLabel,
   });
 
   /// The primary title widget.
@@ -524,6 +548,18 @@ class YaruWindowTitleBar extends StatelessWidget
 
   /// Called when the secondary mouse button is pressed.
   final FutureOr<void> Function(BuildContext)? onShowMenu;
+
+  /// Semantic label used for the close button.
+  final String? closeSemanticLabel;
+
+  /// Semantic label used for the maximize button.
+  final String? maximizeSemanticLabel;
+
+  /// Semantic label used for the minimize button.
+  final String? minimizeSemanticLabel;
+
+  /// Semantic label used for the restore button.
+  final String? restoreSemanticLabel;
 
   /// The tag to use for the [Hero] wrapping the window controls.
   ///
@@ -603,6 +639,10 @@ class YaruWindowTitleBar extends StatelessWidget
           onRestore: onRestore,
           onShowMenu: onShowMenu,
           heroTag: heroTag,
+          closeSemanticLabel: closeSemanticLabel,
+          maximizeSemanticLabel: maximizeSemanticLabel,
+          minimizeSemanticLabel: minimizeSemanticLabel,
+          restoreSemanticLabel: restoreSemanticLabel,
         );
       },
     );
@@ -644,6 +684,10 @@ class YaruDialogTitleBar extends YaruWindowTitleBar {
     super.platform,
     super.buttonPadding,
     super.buttonSpacing,
+    super.closeSemanticLabel,
+    super.maximizeSemanticLabel,
+    super.minimizeSemanticLabel,
+    super.restoreSemanticLabel,
   });
 
   static const defaultShape = RoundedRectangleBorder(

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -38,6 +38,7 @@ class YaruWindowControl extends StatefulWidget {
     required this.onTap,
     this.iconColor,
     this.backgroundColor,
+    this.semanticLabel,
   });
 
   /// Type of this window control, see [YaruWindowControlType].
@@ -62,6 +63,9 @@ class YaruWindowControl extends StatefulWidget {
   /// Color used to draw the control background decoration.
   /// Leave to null, or return null, to use the default value.
   final WidgetStateProperty<Color?>? backgroundColor;
+
+  /// Semantic label used for the control.
+  final String? semanticLabel;
 
   @override
   State<YaruWindowControl> createState() {
@@ -319,20 +323,23 @@ class _YaruWindowControlState extends State<YaruWindowControl>
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return _buildEventDetectors(
-      child: RepaintBoundary(
-        child: _buildBoxDecoration(
-          colorScheme: colorScheme,
-          child: Center(
-            child: AnimatedBuilder(
-              animation: _animationProgress,
-              builder: (context, child) => CustomPaint(
-                size: Size.square(_iconSize),
-                painter: _YaruWindowControlIconPainter(
-                  type: widget.type,
-                  style: style,
-                  iconColor: _getIconColor(colorScheme),
-                  progress: _animationProgress.value,
+    return Semantics(
+      label: widget.semanticLabel,
+      child: _buildEventDetectors(
+        child: RepaintBoundary(
+          child: _buildBoxDecoration(
+            colorScheme: colorScheme,
+            child: Center(
+              child: AnimatedBuilder(
+                animation: _animationProgress,
+                builder: (context, child) => CustomPaint(
+                  size: Size.square(_iconSize),
+                  painter: _YaruWindowControlIconPainter(
+                    type: widget.type,
+                    style: style,
+                    iconColor: _getIconColor(colorScheme),
+                    progress: _animationProgress.value,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Exposes semantic labels for the 4 main window controls so that apps can include text alternative labels for icons.

Related to https://github.com/ubuntu/yaru.dart/pull/1000
