### PR TITLE
fix: availableWidth should be updated when pane resized

### DIFF
--- a/lib/src/widgets/master_detail/yaru_landscape_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_landscape_layout.dart
@@ -41,7 +41,7 @@ class YaruLandscapeLayout extends StatefulWidget {
 
 class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   late int _selectedIndex;
-  double? _paneWidth;
+  late final _paneWidth = ValueNotifier<double?>(0.0);
 
   @override
   void initState() {
@@ -54,6 +54,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   @override
   void dispose() {
     widget.controller.removeListener(_controllerCallback);
+    _paneWidth.dispose();
     super.dispose();
   }
 
@@ -87,13 +88,14 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       page: _buildPage(context),
       layoutDelegate: widget.paneLayoutDelegate,
       includeSeparator: theme.includeSeparator ?? true,
-      onPaneSizeChange: (size) => _paneWidth = size,
+      onPaneSizeChange: (size) => _paneWidth.value = size,
     );
   }
 
   Widget _buildLeftPane(YaruMasterDetailThemeData theme) {
-    return Builder(
-      builder: (context) {
+    return ValueListenableBuilder(
+      valueListenable: _paneWidth,
+      builder: (context, _paneWidth, child) {
         return YaruTitleBarTheme(
           data: const YaruTitleBarThemeData(
             style: YaruTitleBarStyle.undecorated,

--- a/lib/src/widgets/yaru_paned_view.dart
+++ b/lib/src/widgets/yaru_paned_view.dart
@@ -196,6 +196,7 @@ class _YaruPanedViewState extends State<YaruPanedView> {
             _isHovering = false;
           }),
           child: GestureDetector(
+            key: const ValueKey('YaruPanedView.leftPaneResizer'),
             onPanStart: (details) => setState(() {
               _isDragging = true;
               _oldPaneSize = _paneSize;

--- a/test/widgets/yaru_master_detail_page_test.dart
+++ b/test/widgets/yaru_master_detail_page_test.dart
@@ -108,6 +108,87 @@ void main() {
     await tester.pumpAndSettle();
     expectDetailPage(1);
   }, variant: orientationVariant);
+
+  testWidgets('availableWidth is updated with screen resize in portrait', (
+    tester,
+  ) async {
+    const variant = Orientation.portrait;
+    final initialSize = Size(variant.width, 480);
+    const length = 3;
+
+    await tester.pumpScaffold(
+      YaruMasterDetailPage(
+        length: length,
+        paneLayoutDelegate: const YaruFixedPaneDelegate(
+          paneSize: kYaruMasterDetailBreakpoint / 3,
+        ),
+        tileBuilder: (context, index, selected, availableWidth) =>
+            YaruMasterTile(title: Text(availableWidth.toString())),
+        pageBuilder: (context, index) => const SizedBox(),
+      ),
+      size: initialSize,
+    );
+
+    expect(
+      find.text(initialSize.width.toString()),
+      findsNWidgets(length),
+      reason: 'Available width should match initial screen width',
+    );
+
+    final newSize = Size(initialSize.width / 2, initialSize.height);
+    tester.view.physicalSize = newSize;
+    await tester.pump();
+
+    expect(
+      find.text(newSize.width.toString()),
+      findsNWidgets(length),
+      reason: 'Available width should update to new screen width',
+    );
+  });
+
+  testWidgets('availableWidth is updated when pane resized in landscape', (
+    tester,
+  ) async {
+    const variant = Orientation.landscape;
+    const length = 3;
+
+    const initialPaneSize = kYaruMasterDetailBreakpoint / 3;
+    const minPaneSize = initialPaneSize * 0.8;
+
+    await tester.pumpScaffold(
+      YaruMasterDetailPage(
+        length: length,
+        paneLayoutDelegate: const YaruResizablePaneDelegate(
+          initialPaneSize: initialPaneSize,
+          minPaneSize: minPaneSize,
+          minPageSize: 1,
+        ),
+        tileBuilder: (context, index, selected, availableWidth) =>
+            YaruMasterTile(title: Text(availableWidth.toString())),
+        pageBuilder: (context, index) => const SizedBox(),
+      ),
+      size: Size(variant.width, 480),
+    );
+
+    expect(
+      find.text(initialPaneSize.toString()),
+      findsNWidgets(length),
+      reason: 'Available width should match initial pane size',
+    );
+
+    // Resize pane to minimum
+    await tester.drag(
+      find.byKey(const ValueKey('YaruPanedView.leftPaneResizer')),
+      const Offset(-100, 0),
+    );
+    await tester.pump();
+
+    expect(
+      find.text(minPaneSize.toString()),
+      findsNWidgets(length),
+      reason: 'Available width should be updated when pane is resized',
+    );
+  });
 }
 
 final goldenVariant = ValueVariant({


### PR DESCRIPTION
**Bug**:
When resizing the side pane of `YaruMasterDetailPage`, the `tileBuilder` is not rebuilt with the new `availableWidth`.

**Usage scenario**:
I wanted to remove the label when the pane gets small, so there's no overflow, like this:
<img width="671" height="193" alt="image" src="https://github.com/user-attachments/assets/5eef30c3-d3a8-4540-b80d-87f773ea1b03" />
<img width="671" height="193" alt="image" src="https://github.com/user-attachments/assets/f5347de3-8c5b-423c-b9b1-341d7af3db0e" />
```dart
tileBuilder: (context, index, selected, availableWidth) => YaruMasterTile(
  leading: tabs[index].iconBuilder(context, selected),
  title: (availableWidth > 120) ? Text(tabs[index].title) : null,
),
```
The availableWidth in the tileBuilder was not updated when the pane is resized. But manually triggering a hot reload calls the tileBuilder with the new width.

**Fix**:
I wrapped the pane size in a ValueNotifier, and added a ValueListenableBuilder to automatically rebuild the tile when the pane size changes.



***

**Issue template**:

> For a bug fix, please target the `release` branch, else target `main`.

The issue template says to target the `release` branch but it seems out of date. Let me know if this PR needs changing from `main`