### PR TITLE
fix: use scaffold background color instead of hardcoded color and kYaruWindowRadius for titlebars

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -51,7 +51,6 @@ class _MasterDetailPage extends StatelessWidget {
       ),
       pageBuilder: (context, index) => YaruDetailPage(
         appBar: YaruWindowTitleBar(
-          backgroundColor: Colors.transparent,
           border: BorderSide.none,
           leading: Navigator.of(context).canPop()
               ? const YaruBackButton()

--- a/example/lib/pages/tab_bar_page.dart
+++ b/example/lib/pages/tab_bar_page.dart
@@ -28,43 +28,52 @@ class _TabBarPageState extends State<TabBarPage> with TickerProviderStateMixin {
     final theme = Theme.of(context);
     final light = theme.brightness == Brightness.light;
 
-    return Center(
-      child: SimpleDialog(
-        shadowColor: light ? Colors.black : null,
-        titlePadding: EdgeInsets.zero,
-        title: YaruDialogTitleBar(
-          leading: Center(
-            child: YaruOptionButton(
-              onPressed: () {},
-              child: const Icon(YaruIcons.plus),
+    return ColoredBox(
+      color: theme.colorScheme.outline,
+      child: Center(
+        child: SimpleDialog(
+          shadowColor: light ? Colors.black : null,
+          titlePadding: EdgeInsets.zero,
+          title: YaruDialogTitleBar(
+            leading: Center(
+              child: YaruOptionButton(
+                onPressed: () {},
+                child: const Icon(YaruIcons.plus),
+              ),
+            ),
+            title: SizedBox(
+              width: 500,
+              child: YaruTabBar(
+                tabController: tabController,
+                tabs: const [
+                  YaruTab(
+                    label: 'Gaming',
+                    icon: Icon(YaruIcons.game_controller),
+                  ),
+                  YaruTab(label: 'Keyboard', icon: Icon(YaruIcons.keyboard)),
+                  YaruTab(
+                    label: 'Contacts',
+                    icon: Icon(YaruIcons.address_book),
+                  ),
+                ],
+              ),
             ),
           ),
-          title: SizedBox(
-            width: 500,
-            child: YaruTabBar(
-              tabController: tabController,
-              tabs: const [
-                YaruTab(label: 'Gaming', icon: Icon(YaruIcons.game_controller)),
-                YaruTab(label: 'Keyboard', icon: Icon(YaruIcons.keyboard)),
-                YaruTab(label: 'Contacts', icon: Icon(YaruIcons.address_book)),
-              ],
+          children: [
+            SizedBox(
+              width: 600,
+              height: 400,
+              child: TabBarView(
+                controller: tabController,
+                children: const [
+                  Icon(YaruIcons.game_controller),
+                  Icon(YaruIcons.keyboard),
+                  Icon(YaruIcons.address_book),
+                ],
+              ),
             ),
-          ),
+          ],
         ),
-        children: [
-          SizedBox(
-            width: 600,
-            height: 400,
-            child: TabBarView(
-              controller: tabController,
-              children: const [
-                Icon(YaruIcons.game_controller),
-                Icon(YaruIcons.keyboard),
-                Icon(YaruIcons.address_book),
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -174,12 +174,9 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     final light = theme.colorScheme.isLight;
     final highContrast = theme.colorScheme.isHighContrast;
     final states = <WidgetState>{if (isActive != false) WidgetState.focused};
-    final defaultBackgroundColor = WidgetStateProperty.resolveWith((states) {
-      if (!states.contains(WidgetState.focused)) {
-        return theme.colorScheme.surface;
-      }
-      return light ? YaruColors.titleBarLight : YaruColors.titleBarDark;
-    });
+    final defaultBackgroundColor = WidgetStateProperty.resolveWith(
+      (states) => theme.scaffoldBackgroundColor,
+    );
     final backgroundColor =
         WidgetStateProperty.resolveAs(this.backgroundColor, states) ??
         titleBarTheme.backgroundColor?.resolve(states) ??
@@ -330,7 +327,9 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                                   ? closeButton
                                   : ClipRRect(
                                       borderRadius: const BorderRadius.only(
-                                        topRight: Radius.circular(6),
+                                        topRight: Radius.circular(
+                                          kYaruWindowRadius,
+                                        ),
                                       ),
                                       child: closeButton,
                                     ),
@@ -692,7 +691,7 @@ class YaruDialogTitleBar extends YaruWindowTitleBar {
 
   static const defaultShape = RoundedRectangleBorder(
     borderRadius: BorderRadius.vertical(
-      top: Radius.circular(kYaruContainerRadius),
+      top: Radius.circular(kYaruWindowRadius),
     ),
   );
 


### PR DESCRIPTION
@juanruitina

the titlebar colors was hardcoded. i wondered what would be the best theme color as a default (it can be manually overwritten). I thought since you guys go with this look in the installer this might be a good choice?

<img width="1258" height="1038" alt="Bildschirmfoto 2025-07-27 um 11 43 55" src="https://github.com/user-attachments/assets/74581c5e-33fa-496f-a707-aa027ff03ef3" />


Fixes #1008
