### PR TITLE
fix: the bottomAppBarTheme requires BottomAppBarThemeData instead  BottomAppBarTheme

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -755,7 +755,7 @@ ThemeData createYaruTheme({
     menuTheme: _createMenuTheme(colorScheme),
     popupMenuTheme: _createPopupMenuTheme(colorScheme),
     tooltipTheme: _tooltipThemeData,
-    bottomAppBarTheme: BottomAppBarTheme(color: colorScheme.surface),
+    bottomAppBarTheme: BottomAppBarThemeData(color: colorScheme.surface),
     navigationBarTheme: _createNavigationBarTheme(colorScheme),
     navigationRailTheme: _createNavigationRailTheme(colorScheme),
     dividerTheme: DividerThemeData(


### PR DESCRIPTION
<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
