### PR TITLE
fix(a11y): Increase page indicator contrast

### DIFF
--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -261,7 +261,7 @@ class YaruPageIndicatorItem extends StatelessWidget {
     final decoration = BoxDecoration(
       color: selected
           ? theme.colorScheme.primary
-          : theme.colorScheme.onSurface.withValues(alpha: 0.3),
+          : theme.colorScheme.onSurface.withValues(alpha: 0.6),
       shape: borderRadius == null ? BoxShape.circle : BoxShape.rectangle,
       borderRadius: borderRadius,
     );


### PR DESCRIPTION
Contrast should be at least 3:1 for the inactive dots, this brings the contrast in light mode just above 3:1, and contrast in dark mode is just above 6:1.

| | Dark | Light |
|-|------|-------|
| This PR | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/903cf411-fa31-449b-8e77-a359f4f933cf" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/df82328c-e361-46ba-83fe-d868d1b12ed7" /> |
| Current | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/314ed1e0-0f76-4b70-933e-cecd84d64d7d" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/c990e1da-92a6-49bf-a082-a7ea4d7eb7f4" /> |

---

UDENG-7682
