### PR TITLE
feat(YaruExpandable): add `usePadding` flag

### DIFF
--- a/example/lib/pages/expandable_page.dart
+++ b/example/lib/pages/expandable_page.dart
@@ -16,6 +16,7 @@ class ExpandablePage extends StatelessWidget {
           padding: const EdgeInsets.all(kYaruPagePadding),
           children: const [
             YaruExpandable(
+              usePadding: true,
               header: Text(
                 'Lorem ipsum dolor sit amet',
                 style: TextStyle(fontWeight: FontWeight.bold),
@@ -29,6 +30,7 @@ class ExpandablePage extends StatelessWidget {
                 maxLines: 5,
                 overflow: TextOverflow.fade,
               ),
+              usePadding: true,
               header: Text(
                 'Lorem ipsum dolor sit amet',
                 style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/src/widgets/yaru_expandable.dart
+++ b/lib/src/widgets/yaru_expandable.dart
@@ -27,6 +27,7 @@ class YaruExpandable extends StatefulWidget {
     this.gapHeight = 4.0,
     this.isExpanded = false,
     this.onChange,
+    this.usePadding = false,
   });
 
   /// Widget placed in the header, against the expand button.
@@ -60,6 +61,17 @@ class YaruExpandable extends StatefulWidget {
 
   /// Callback called on expand or collapse.
   final ValueChanged<bool>? onChange;
+
+  /// If true, a [Padding] will be used instead of a [Column],
+  /// around the [child] widget to add a gap between [header] and [child].
+  /// This avoids unexpected behaviour with [Column], especially with a child
+  /// that is not well sized.
+  ///
+  /// See: [#1024](https://github.com/ubuntu/yaru.dart/issues/1024)
+  ///
+  /// In the next major release, the [Padding] will be the default behaviour,
+  /// and this flag will be removed.
+  final bool usePadding;
 
   @override
   State<YaruExpandable> createState() => _YaruExpandableState();
@@ -152,6 +164,13 @@ class _YaruExpandableState extends State<YaruExpandable> {
   }
 
   Widget _buildChild(Widget child) {
+    if (widget.usePadding) {
+      return Padding(
+        padding: EdgeInsetsGeometry.only(top: widget.gapHeight),
+        child: child,
+      );
+    }
+
     return Column(
       children: [
         SizedBox(height: widget.gapHeight),

--- a/test/widgets/yaru_expandable_test.dart
+++ b/test/widgets/yaru_expandable_test.dart
@@ -17,6 +17,7 @@ void main() {
           body: YaruExpandable(
             isExpanded: isExpanded,
             onChange: (value) => isExpanded = value,
+            usePadding: true,
             header: const Text(kHeaderText),
             child: const Text(kContentText),
           ),
@@ -48,6 +49,7 @@ void main() {
           body: YaruExpandable(
             isExpanded: isExpanded,
             onChange: (value) => isExpanded = value,
+            usePadding: true,
             header: const Text(kHeaderText),
             child: const Text(kContentText),
           ),
@@ -79,6 +81,7 @@ void main() {
           body: YaruExpandable(
             isExpanded: isExpanded,
             onChange: (value) => isExpanded = value,
+            usePadding: true,
             header: const Text(kHeaderText),
             child: const Text(kContentText),
           ),


### PR DESCRIPTION
If true, a `Padding` will be used instead of a `Column` around the child widget to add a gap between `header` and `child`. This avoids unexpected behaviour with `Column`, especially with a child that is not well sized.

In the next major release, we can use `Padding` as the default behaviour, and remove this flag.

Fixes #1024