### PR TITLE
feat(a11y): Automatically enable status shapes

### DIFF
--- a/example/lib/pages/switch_page.dart
+++ b/example/lib/pages/switch_page.dart
@@ -31,17 +31,6 @@ class _SwitchPageState extends State<SwitchPage> {
                   const SizedBox(width: 10),
                   YaruSwitch(value: _switchValues[i], onChanged: null),
                   const SizedBox(width: 10),
-                  YaruSwitch(
-                    value: _switchValues[i],
-                    onChanged: (v) => setState(() => _switchValues[i] = v),
-                    onOffShapes: true,
-                  ),
-                  const SizedBox(width: 10),
-                  YaruSwitch(
-                    value: _switchValues[i],
-                    onChanged: null,
-                    onOffShapes: true,
-                  ),
                 ],
               ),
               const SizedBox(height: 10),

--- a/lib/src/settings/gtk_constants.dart
+++ b/lib/src/settings/gtk_constants.dart
@@ -1,2 +1,5 @@
 const kSchemaInterface = 'org.gnome.desktop.interface';
 const kAccentColorKey = 'accent-color';
+
+const kA11ySchemaInterface = 'org.gnome.desktop.a11y.interface';
+const kStatusShapesKey = 'show-status-shapes';

--- a/lib/src/settings/inherited_theme.dart
+++ b/lib/src/settings/inherited_theme.dart
@@ -144,12 +144,16 @@ class _YaruThemeState extends State<YaruTheme> {
   YaruSettings? _settings;
   StreamSubscription<String?>? _themeNameSubscription;
   StreamSubscription<String?>? _accentColorSubScription;
+  StreamSubscription<bool?>? _statusShapesSubscription;
+
+  bool? _statusShapes;
 
   @override
   void initState() {
     super.initState();
     if (widget.data.variant == null && canDetectVariant()) {
       _settings = widget._settings ?? YaruSettings();
+
       _settings?.init();
       _variant =
           resolveAccentColorVariant(_settings?.getAccentColor()) ??
@@ -160,6 +164,12 @@ class _YaruThemeState extends State<YaruTheme> {
       _themeNameSubscription ??= _settings!.themeNameChanged.listen(
         updateVariant,
       );
+      _statusShapesSubscription ??= _settings!.statusShapesChanged.listen(
+        (v) => setState(() {
+          _statusShapes = v;
+        }),
+      );
+      _settings?.getStatusShapes();
     }
   }
 
@@ -167,6 +177,7 @@ class _YaruThemeState extends State<YaruTheme> {
   void dispose() {
     _themeNameSubscription?.cancel();
     _accentColorSubScription?.cancel();
+    _statusShapesSubscription?.cancel();
     _settings?.dispose();
     super.dispose();
   }
@@ -250,6 +261,7 @@ class _YaruThemeState extends State<YaruTheme> {
       highContrast:
           widget.data.highContrast ?? MediaQuery.highContrastOf(context),
       themeMode: resolveMode(),
+      statusShapes: _statusShapes,
     );
   }
 
@@ -289,6 +301,7 @@ class YaruThemeData with Diagnosticable {
     this.pageTransitionsTheme,
     this.useMaterial3,
     this.visualDensity,
+    this.statusShapes,
   });
 
   /// Specifies the theme variant.
@@ -312,6 +325,8 @@ class YaruThemeData with Diagnosticable {
   /// Overrides [ThemeData.visualDensity].
   final VisualDensity? visualDensity;
 
+  final bool? statusShapes;
+
   /// The light theme of [variant] (or [yaruLight] if not available) merged with
   /// the `YaruThemeData` overrides.
   ThemeData? get theme => (variant?.theme ?? yaruLight).overrideWith(this);
@@ -330,6 +345,7 @@ class YaruThemeData with Diagnosticable {
     PageTransitionsTheme? pageTransitionsTheme,
     bool? useMaterial3,
     VisualDensity? visualDensity,
+    bool? statusShapes,
   }) {
     return YaruThemeData(
       variant: variant ?? this.variant,
@@ -339,6 +355,7 @@ class YaruThemeData with Diagnosticable {
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       useMaterial3: useMaterial3 ?? this.useMaterial3,
       visualDensity: visualDensity ?? this.visualDensity,
+      statusShapes: statusShapes ?? this.statusShapes,
     );
   }
 
@@ -367,7 +384,8 @@ class YaruThemeData with Diagnosticable {
         iterableEquals(other.extensions, extensions) &&
         other.pageTransitionsTheme == pageTransitionsTheme &&
         other.useMaterial3 == useMaterial3 &&
-        other.visualDensity == visualDensity;
+        other.visualDensity == visualDensity &&
+        other.statusShapes == statusShapes;
   }
 
   @override
@@ -380,6 +398,7 @@ class YaruThemeData with Diagnosticable {
       pageTransitionsTheme,
       useMaterial3,
       visualDensity,
+      statusShapes,
     );
   }
 }

--- a/lib/src/settings/yaru_settings.dart
+++ b/lib/src/settings/yaru_settings.dart
@@ -11,8 +11,10 @@ abstract class YaruSettings {
 
   String? getThemeName();
   String? getAccentColor();
+  bool? getStatusShapes();
   Stream<String?> get themeNameChanged;
   Stream<String?> get accentColorChanged;
+  Stream<bool?> get statusShapesChanged;
   void init();
   Future<void> dispose();
 }
@@ -28,6 +30,7 @@ class YaruGtkSettings extends YaruSettings {
   final GtkSettings _gtkSettings;
   final GSettingsService _gSettingsService;
   GnomeSettings? _gSettings;
+  GnomeSettings? _gA11ySettings;
 
   @override
   String? getThemeName() => _gtkSettings.getProperty(kGtkThemeName) as String?;
@@ -40,10 +43,19 @@ class YaruGtkSettings extends YaruSettings {
   @override
   Stream<String?> get accentColorChanged => _accentColorController.stream;
 
+  final _statusShapesController = StreamController<bool?>.broadcast();
+  @override
+  Stream<bool?> get statusShapesChanged => _statusShapesController.stream;
+
   @override
   void init() {
     _gSettings ??= _gSettingsService.lookup(kSchemaInterface);
     _gSettings?.addListener(() => _accentColorController.add(getAccentColor()));
+
+    _gA11ySettings ??= _gSettingsService.lookup(kA11ySchemaInterface);
+    _gA11ySettings?.addListener(
+      () => _statusShapesController.add(getStatusShapes()),
+    );
   }
 
   @override
@@ -54,4 +66,7 @@ class YaruGtkSettings extends YaruSettings {
 
   @override
   String? getAccentColor() => _gSettings?.stringValue(kAccentColorKey);
+
+  @override
+  bool? getStatusShapes() => _gA11ySettings?.boolValue(kStatusShapesKey);
 }

--- a/lib/src/widgets/yaru_switch.dart
+++ b/lib/src/widgets/yaru_switch.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yaru/theme.dart';
+import 'package:yaru/yaru.dart';
 
 import 'yaru_checkbox.dart';
 import 'yaru_radio.dart';
@@ -160,7 +161,10 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
   Widget build(BuildContext context) {
     final switchTheme = YaruSwitchTheme.of(context);
     final colorScheme = Theme.of(context).colorScheme;
-    final painter = _YaruSwitchPainter(onOffShapes: widget.onOffShapes);
+    final settings = YaruTheme.of(context);
+    final painter = _YaruSwitchPainter(
+      onOffShapes: widget.onOffShapes ?? settings.statusShapes,
+    );
     fillPainterDefaults(painter);
 
     const unselectedState = <WidgetState>{};

--- a/lib/src/widgets/yaru_switch.dart
+++ b/lib/src/widgets/yaru_switch.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:yaru/theme.dart';
 import 'package:yaru/yaru.dart';
 
-import 'yaru_checkbox.dart';
-import 'yaru_radio.dart';
-import 'yaru_switch_button.dart';
-import 'yaru_switch_theme.dart';
 import 'yaru_togglable.dart';
 
 const _kSwitchActivableAreaPadding = EdgeInsets.symmetric(
@@ -161,9 +156,9 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
   Widget build(BuildContext context) {
     final switchTheme = YaruSwitchTheme.of(context);
     final colorScheme = Theme.of(context).colorScheme;
-    final settings = YaruTheme.of(context);
+    final settings = YaruTheme.maybeOf(context);
     final painter = _YaruSwitchPainter(
-      onOffShapes: widget.onOffShapes ?? settings.statusShapes,
+      onOffShapes: widget.onOffShapes ?? settings?.statusShapes,
     );
     fillPainterDefaults(painter);
 


### PR DESCRIPTION
Automatically toggle on/off (status) shapes for switches based on the gnome setting. On Ubuntu, this setting is located in Settings > Accessibility > On/Off Shapes.

---

UDENG-7712
