### PR TITLE
fix: Use square corners for window controls when maximized

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -323,7 +323,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                                 semanticLabel: maximizeSemanticLabel,
                               ),
                             if (isClosable == true)
-                              isMaximizable == true
+                              (isMaximizable == true || isRestorable == true)
                                   ? closeButton
                                   : ClipRRect(
                                       borderRadius: const BorderRadius.only(


### PR DESCRIPTION
This PR fixes a visual inconsistency where the close button on windows retains rounded corners even when the window is maximized.

The fix ensures that window controls use square corners in maximized state, matching the behavior of native platform conventions on windows.

_Visual Comparison_

Before (rounded corners when maximized):
<img width="140" height="59" alt="Current Yaru close button with rounded corners" src="https://github.com/user-attachments/assets/86c65af0-2d63-42c4-b7e7-ebfa5857ae76" />

After (square corners when maximized):
<img width="157" height="61" alt="Windows close button with square corners when maximized" src="https://github.com/user-attachments/assets/c0b19440-16f8-423c-873c-673d4bae28e5" />

I wasn't able to regenerate the golden test images due to font-related issues on my system but I hope this change is minimal enough (and not covered by the tests I think)