### PR TITLE
fix(a11y): Increase visibility of color disk borders

### DIFF
--- a/lib/src/widgets/yaru_color_disk.dart
+++ b/lib/src/widgets/yaru_color_disk.dart
@@ -28,6 +28,8 @@ class YaruColorDisk extends StatelessWidget {
             shape: WidgetStateProperty.resolveWith<OutlinedBorder?>((states) {
               return CircleBorder(
                 side: BorderSide(
+                  strokeAlign: 1,
+                  width: 2,
                   color: color.withValues(
                     alpha:
                         states.contains(WidgetState.selected) ||


### PR DESCRIPTION
Small PR to increase the visibility of the border on the YaruColorDisk.

| This PR | Existing |
|---------|----------|
| <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/89b22bce-cc48-4d98-9a62-35abda07d02b" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/854082db-a066-41ba-a7ba-ca8112f0a9b0" /> |

---

UDENG-8469
