### PR TITLE
feat(a11y): Add YaruFocusBorder widget

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -32,3 +32,6 @@ const kYaruTitleBarItemHeight = 34.0;
 
 /// The default icon size
 const kYaruIconSize = 20.0;
+
+/// The default border width for various Yaru widgets.
+const kYaruBorderWidth = 2.0;

--- a/lib/src/widgets/yaru_focus_border.dart
+++ b/lib/src/widgets/yaru_focus_border.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/constants.dart';
+
+enum _YaruFocusBorderVariant { primary, secondary, onSurface }
+
+/// Padding between the border and child widget.
+class YaruFocusBorderPadding {
+  static const zero = EdgeInsetsGeometry.zero;
+  static const small = EdgeInsets.all(2);
+  static const medium = EdgeInsets.all(4);
+  static const large = EdgeInsets.all(6);
+}
+
+/// Draws a border around the child widget when focused.
+class YaruFocusBorder extends StatefulWidget {
+  YaruFocusBorder({
+    required this.child,
+    this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
+    this.borderStrokeAlign,
+    this.borderPadding,
+    this.focused,
+    this.onFocusChange,
+  }) : _variant = _YaruFocusBorderVariant.primary;
+
+  const YaruFocusBorder.primary({
+    required this.child,
+    this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
+    this.borderStrokeAlign,
+    this.borderPadding,
+    this.focused,
+    this.onFocusChange,
+  }) : _variant = _YaruFocusBorderVariant.primary;
+
+  const YaruFocusBorder.secondary({
+    required this.child,
+    this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
+    this.borderStrokeAlign,
+    this.borderPadding,
+    this.focused,
+    this.onFocusChange,
+  }) : _variant = _YaruFocusBorderVariant.secondary;
+
+  const YaruFocusBorder.onSurface({
+    required this.child,
+    this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
+    this.borderStrokeAlign,
+    this.borderPadding,
+    this.focused,
+    this.onFocusChange,
+  }) : _variant = _YaruFocusBorderVariant.onSurface;
+
+  final _YaruFocusBorderVariant _variant;
+  final Widget child;
+
+  /// See [BoxDecoration.borderRadius]
+  final BorderRadiusGeometry? borderRadius;
+
+  /// See [BoxDecoration.color]
+  final Color? borderColor;
+
+  /// See [BorderSide.width]
+  final double? borderWidth;
+
+  /// See [BorderSide.strokeAlign]
+  final double? borderStrokeAlign;
+
+  /// See [AnimatedContainer.padding]
+  final EdgeInsetsGeometry? borderPadding;
+
+  /// Whether the child is focused or not.
+  final bool? focused;
+
+  /// Callback called when the focus changes.
+  final void Function(bool)? onFocusChange;
+
+  @override
+  State<YaruFocusBorder> createState() => _YaruFocusBorderState();
+}
+
+class _YaruFocusBorderState extends State<YaruFocusBorder> {
+  bool _focused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focused = widget.focused ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final borderColor =
+        widget.borderColor ??
+        switch (widget._variant) {
+          _YaruFocusBorderVariant.primary => theme.colorScheme.primary,
+          _YaruFocusBorderVariant.secondary => theme.colorScheme.secondary,
+          _YaruFocusBorderVariant.onSurface => theme.colorScheme.onSurface,
+        };
+
+    return AnimatedContainer(
+      duration: Durations.medium1,
+      padding: widget.borderPadding ?? YaruFocusBorderPadding.small,
+      decoration: BoxDecoration(
+        border: BoxBorder.all(
+          strokeAlign: widget.borderStrokeAlign ?? 2,
+          color: _focused ? borderColor : Colors.transparent,
+          width: widget.borderWidth ?? kYaruBorderWidth,
+        ),
+        borderRadius:
+            widget.borderRadius ??
+            const BorderRadius.all(Radius.circular(kYaruButtonRadius + 2)),
+      ),
+      child: InkWell(
+        onFocusChange: (value) => widget.onFocusChange != null
+            ? widget.onFocusChange!(value)
+            : setState(() {
+                _focused = value;
+              }),
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/yaru_focus_border.dart
+++ b/lib/src/widgets/yaru_focus_border.dart
@@ -108,10 +108,10 @@ class _YaruFocusBorderState extends State<YaruFocusBorder> {
 
     return AnimatedContainer(
       duration: Durations.medium1,
-      padding: widget.borderPadding ?? YaruFocusBorderPadding.small,
-      decoration: BoxDecoration(
+      padding: widget.borderPadding ?? YaruFocusBorderPadding.zero,
+      foregroundDecoration: BoxDecoration(
         border: BoxBorder.all(
-          strokeAlign: widget.borderStrokeAlign ?? 2,
+          strokeAlign: widget.borderStrokeAlign ?? 3,
           color: _focused ? borderColor : Colors.transparent,
           width: widget.borderWidth ?? kYaruBorderWidth,
         ),

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -24,6 +24,7 @@ export 'src/widgets/yaru_date_time_entry.dart';
 export 'src/widgets/yaru_draggable.dart';
 export 'src/widgets/yaru_expandable.dart';
 export 'src/widgets/yaru_expansion_panel.dart';
+export 'src/widgets/yaru_focus_border.dart';
 export 'src/widgets/yaru_icon_button.dart';
 export 'src/widgets/yaru_info.dart';
 export 'src/widgets/yaru_linear_progress_indicator.dart';


### PR DESCRIPTION
Adds a `YaruFocusBorder` widget which can wrap most children and provide it a focus border without having to define custom borders for widgets individually. Obviously, this type of thing should be added by Flutter eventually, but this is a much easier (and more aligned with our style goals) holdover until then.

This should be able to be used to wrap virtually any focus-able widget, including regular buttons, tiles, etc.

<details>
<summary>Examples of wrapping some Yaru widgets with this</summary>

| Widget | Image |
|--------|-------|
| YaruSwitchButton (primary) | <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/98e70d6d-c2f0-479f-ac6c-586220a0434b" /> |
| YaruSwitchButton (dropdown) | <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/333ca915-c805-4c65-87a1-8288434eada0" /> |
| YaruCheckboxButton | <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/3f3e378f-56f9-44ac-aec8-4d35ed09162e" /> |
| YaruIconButton | <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/3b6fa52f-6488-4763-b671-5db8cb6444ad" /> <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/308b1bf7-1246-4c8f-a6db-b7573e829403" /> |
| YaruSelectableContainer | <img width="826" height="1036" alt="image" src="https://github.com/user-attachments/assets/6048ec62-8313-4fa6-88ca-2c882b9b5394" /> |

</details>

Related https://github.com/ubuntu/yaru.dart/issues/979