### PR TITLE
fix(a11y): Thicken borders around text inputs

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -34,4 +34,4 @@ const kYaruTitleBarItemHeight = 34.0;
 const kYaruIconSize = 20.0;
 
 /// The default border width for various Yaru widgets.
-const kYaruBorderWidth = 2.0;
+const kYaruFocusBorderWidth = 2.0;

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -39,7 +39,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
 
 InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final radius = BorderRadius.circular(kYaruButtonRadius);
-  const width = 1.0;
+  const width = kYaruBorderWidth;
   const strokeAlign = 0.0;
   final fill = colorScheme.surface.scale(
     lightness: colorScheme.isLight ? -0.05 : -0.1,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -39,7 +39,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
 
 InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final radius = BorderRadius.circular(kYaruButtonRadius);
-  const width = kYaruBorderWidth;
+  const width = kYaruFocusBorderWidth;
   const strokeAlign = 0.0;
   final fill = colorScheme.surface.scale(
     lightness: colorScheme.isLight ? -0.05 : -0.1,

--- a/lib/src/widgets/yaru_focus_border.dart
+++ b/lib/src/widgets/yaru_focus_border.dart
@@ -113,7 +113,7 @@ class _YaruFocusBorderState extends State<YaruFocusBorder> {
         border: BoxBorder.all(
           strokeAlign: widget.borderStrokeAlign ?? 3,
           color: _focused ? borderColor : Colors.transparent,
-          width: widget.borderWidth ?? kYaruBorderWidth,
+          width: widget.borderWidth ?? kYaruFocusBorderWidth,
         ),
         borderRadius:
             widget.borderRadius ??


### PR DESCRIPTION
Another small adjustment: thicken the input border from 1 to 2.

| Existing | This PR |
|----------|---------|
| <img width="887" height="1042" alt="image" src="https://github.com/user-attachments/assets/07f4b76e-d18a-43ac-98cc-150ef061f5ba" /> <img width="887" height="1042" alt="image" src="https://github.com/user-attachments/assets/e06c8238-c644-4e79-af62-06db2df398da" /> | <img width="887" height="1042" alt="image" src="https://github.com/user-attachments/assets/5c563d1b-4b41-408f-b482-4998f192c561" /> <img width="887" height="1042" alt="image" src="https://github.com/user-attachments/assets/9606e8e0-142f-4208-aa11-e44c38396ae4" /> |

Related https://github.com/ubuntu/yaru.dart/issues/979
> In form fields, outline should replace existing borders (2px, inside).