### PR TITLE
fix(example): correct code snippet url in draggable page example

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -147,7 +147,7 @@ final examplePageItems = <PageItem>[
     title: 'YaruDraggable',
     floatingActionButtonBuilder: (_) => const CodeSnippedButton(
       snippetUrl:
-          'https://raw.githubusercontent.com/ubuntu/yaru.dart/main/example/lib/pages/draffable_page.dart',
+          'https://raw.githubusercontent.com/ubuntu/yaru.dart/main/example/lib/pages/draggable_page.dart',
     ),
     pageBuilder: (context) => const DraggablePage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.drag_handle),


### PR DESCRIPTION
In the example application, the code snippet for the draggable page did not load.
<img width="298" height="106" alt="image" src="https://github.com/user-attachments/assets/35bc730a-191e-4882-90ee-804a88aa611d" />

I fixed the typo, so the snippet shows up again.
<img width="679" height="1291" alt="image" src="https://github.com/user-attachments/assets/d0e6ba33-80b8-4319-958b-7a31c7dd97e9" />
