### PR TITLE
feat: make theme and darkTheme non-nullable

### DIFF
--- a/lib/src/settings/inherited_theme.dart
+++ b/lib/src/settings/inherited_theme.dart
@@ -333,11 +333,11 @@ class YaruThemeData with Diagnosticable {
 
   /// The light theme of [variant] (or [yaruLight] if not available) merged with
   /// the `YaruThemeData` overrides.
-  ThemeData? get theme => (variant?.theme ?? yaruLight).overrideWith(this);
+  ThemeData get theme => (variant?.theme ?? yaruLight).overrideWith(this);
 
   /// The dark theme of [variant] (or [yaruDark] if not available) merged with
   /// the `YaruThemeData` overrides.
-  ThemeData? get darkTheme =>
+  ThemeData get darkTheme =>
       (variant?.darkTheme ?? yaruDark).overrideWith(this);
 
   /// Creates a copy of this [YaruThemeData] with the provided values.


### PR DESCRIPTION
Makes `YaruThemeData.theme` and `YaruThemeData.darkTheme` return a `ThemeData` instead of `ThemeData?`.
No changes were made other than removing the two question marks.

This means users of the package don't have to deal with null values, e.g.:
```patch
 return YaruTheme(
   builder: (context, yaru, _) {
     return MaterialApp(
       key: _appKey,
-      theme: yaru.theme ?? yaruLight,
-      darkTheme: yaru.darkTheme ?? yaruDark,
+      theme: yaru.theme,
+      darkTheme: yaru.darkTheme,
       debugShowCheckedModeBanner: false,
       home: const ConnectPage(),
     );
   },
 );
```