### PR TITLE
fix: Split button spacing

### DIFF
--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -63,7 +63,7 @@ class YaruSplitButton extends StatelessWidget {
 
     final dropdownShape = switch (_variant) {
       _YaruSplitButtonVariant.outlined => NonUniformRoundedRectangleBorder(
-        hideLeftSide: false,
+        hideLeftSide: true,
         borderRadius: BorderRadius.horizontal(
           right: defaultRadius,
           left: Radius.zero,
@@ -172,7 +172,8 @@ class YaruSplitButton extends StatelessWidget {
               )
             : mainButton,
         if (onDropdownPressed != null) ...[
-          const SizedBox(width: 2),
+          if (_variant != _YaruSplitButtonVariant.outlined)
+            const SizedBox(width: 1),
           hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
               ? YaruFocusBorder.primary(
                   borderRadius: dropdownBorderRadius,

--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -57,10 +57,7 @@ class YaruSplitButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: fix common_themes to use a fixed size for buttons instead of fiddling around with padding
-    // then we can rely on this size here
-    const size = Size.square(36);
-    const dropdownPadding = EdgeInsets.only(top: 16, bottom: 16);
+    const dropdownSize = Size(45, 0);
 
     final defaultRadius = Radius.circular(radius ?? kYaruButtonRadius);
 
@@ -140,10 +137,7 @@ class YaruSplitButton extends StatelessWidget {
     final dropdownButton = switch (_variant) {
       _YaruSplitButtonVariant.elevated => ElevatedButton(
         style: ElevatedButton.styleFrom(
-          fixedSize: size,
-          minimumSize: size,
-          maximumSize: size,
-          padding: dropdownPadding,
+          minimumSize: dropdownSize,
           shape: dropdownShape,
         ),
         onPressed: onDropdownPressed,
@@ -151,10 +145,7 @@ class YaruSplitButton extends StatelessWidget {
       ),
       _YaruSplitButtonVariant.filled => FilledButton(
         style: FilledButton.styleFrom(
-          fixedSize: size,
-          minimumSize: size,
-          maximumSize: size,
-          padding: dropdownPadding,
+          minimumSize: dropdownSize,
           shape: dropdownShape,
         ),
         onPressed: onDropdownPressed,
@@ -162,10 +153,7 @@ class YaruSplitButton extends StatelessWidget {
       ),
       _YaruSplitButtonVariant.outlined => OutlinedButton(
         style: OutlinedButton.styleFrom(
-          fixedSize: size,
-          minimumSize: size,
-          maximumSize: size,
-          padding: dropdownPadding,
+          minimumSize: dropdownSize,
           shape: dropdownShape,
         ),
         onPressed: onDropdownPressed,
@@ -175,6 +163,7 @@ class YaruSplitButton extends StatelessWidget {
 
     return Row(
       mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
             ? YaruFocusBorder.primary(


### PR DESCRIPTION
Reduces the space between filled split buttons to 1 and removes the gap between outlined split buttons.

See the first row of https://github.com/ubuntu/yaru.dart/issues/1047#issuecomment-3634719201 for what this looks like.

This also fixes an issue where the dropdown button was 1px smaller than the main button. At first this was a simple size change, but I think the solution now is more robust (https://github.com/ubuntu/yaru.dart/pull/1051/commits/80a0bb0a50b2eb54cc7d62016dff48dd2f7614a9). It should handle larger/smaller main button sizes gracefully, like so:

<img width="910" height="1014" alt="image" src="https://github.com/user-attachments/assets/edc092ce-f937-4a6b-80ff-45f1c8dcc8fa" />

A button with unstyled text (or smaller) still has a square dropdown button as before, but if the size is increased, the dropdown button will just increase in height instead of staying the same. 

Fixes https://github.com/ubuntu/yaru.dart/issues/1047

---

UDENG-8681