### PR TITLE
feat: Add YaruListTile and YaruTileList

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -193,14 +193,14 @@ class SettingsDialog extends StatelessWidget with WatchItMixin {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          YaruTile(
+          YaruListTile(
             title: const Text('Compact mode'),
             trailing: YaruSwitch(
               value: watchPropertyValue((ExampleModel m) => m.compactMode),
               onChanged: (v) => model.compactMode = v,
             ),
           ),
-          YaruTile(
+          YaruListTile(
             title: const Text('RTL mode'),
             trailing: YaruSwitch(
               value: watchPropertyValue((ExampleModel m) => m.rtl),

--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -20,6 +20,7 @@ import 'pages/full_color_icons_page.dart';
 import 'pages/icon_button_page.dart';
 import 'pages/icons_page/icons_page.dart';
 import 'pages/info_page.dart';
+import 'pages/list_tile.dart';
 import 'pages/navigation_page.dart';
 import 'pages/option_button_page.dart';
 import 'pages/page_indicator.dart';
@@ -306,6 +307,11 @@ final examplePageItems = <PageItem>[
     ),
     iconBuilder: (context, selected) => const Icon(YaruIcons.unordered_list),
     pageBuilder: (_) => const TilePage(),
+  ),
+  PageItem(
+    title: 'YaruListTile',
+    pageBuilder: (context) => const ListTilePage(),
+    iconBuilder: (context, selected) => const Icon(YaruIcons.unordered_list),
   ),
   PageItem(
     title: 'YaruDialogTitleBar',

--- a/example/lib/pages/clip_page.dart
+++ b/example/lib/pages/clip_page.dart
@@ -13,7 +13,7 @@ class ClipPage extends StatelessWidget {
           padding: const EdgeInsets.all(kYaruPagePadding),
           children: [
             for (final position in YaruDiagonalClip.values)
-              YaruTile(
+              YaruListTile(
                 leading: Container(
                   width: 40,
                   height: 40,

--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -18,7 +18,7 @@ class _DialogPageState extends State<DialogPage> {
         padding: const EdgeInsets.all(kYaruPagePadding),
         child: Column(
           children: [
-            YaruTile(
+            YaruListTile(
               title: const Text('YaruDialogTitleBar'),
               trailing: OutlinedButton(
                 onPressed: () => showDialog(
@@ -73,7 +73,7 @@ class _DialogPageState extends State<DialogPage> {
                 child: const Text('Open dialog'),
               ),
             ),
-            YaruTile(
+            YaruListTile(
               title: const Text('isCloseable'),
               trailing: YaruSwitch(
                 value: isCloseable,

--- a/example/lib/pages/list_tile.dart
+++ b/example/lib/pages/list_tile.dart
@@ -17,20 +17,23 @@ class _ListTilePageState extends State<ListTilePage> {
           controller: controller,
           padding: const EdgeInsets.all(kYaruPagePadding),
           children: [
-            const YaruListTile(titleText: 'YaruListTile'),
-            const YaruListTile(
+            YaruListTile(titleText: 'YaruListTile', onTap: () {}),
+            YaruListTile(
               titleText: 'YaruListTile',
               subtitleText: 'YaruListTile subtitle',
+              onTap: () {},
             ),
-            const YaruListTile(
+            YaruListTile(
               titleText: 'YaruListTile',
               subtitleText: 'YaruListTile subtitle',
-              leading: Icon(YaruIcons.ubuntu_logo_simple),
+              leading: const Icon(YaruIcons.ubuntu_logo_simple),
+              onTap: () {},
             ),
-            const YaruListTile(
+            YaruListTile(
               titleText: 'YaruListTile',
               subtitleText: 'YaruListTile subtitle',
-              trailing: Icon(YaruIcons.ubuntu_logo_simple),
+              trailing: const Icon(YaruIcons.ubuntu_logo_simple),
+              onTap: () {},
             ),
             YaruTileList(
               children: [

--- a/example/lib/pages/list_tile.dart
+++ b/example/lib/pages/list_tile.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+class ListTilePage extends StatefulWidget {
+  const ListTilePage({super.key});
+
+  @override
+  State<ListTilePage> createState() => _ListTilePageState();
+}
+
+class _ListTilePageState extends State<ListTilePage> {
+  @override
+  Widget build(BuildContext context) {
+    return YaruScrollViewUndershoot.builder(
+      builder: (context, controller) {
+        return ListView(
+          controller: controller,
+          padding: const EdgeInsets.all(kYaruPagePadding),
+          children: [
+            const YaruListTile(titleText: 'YaruListTile'),
+            const YaruListTile(
+              titleText: 'YaruListTile',
+              subtitleText: 'YaruListTile subtitle',
+            ),
+            const YaruListTile(
+              titleText: 'YaruListTile',
+              subtitleText: 'YaruListTile subtitle',
+              leading: Icon(YaruIcons.ubuntu_logo_simple),
+            ),
+            const YaruListTile(
+              titleText: 'YaruListTile',
+              subtitleText: 'YaruListTile subtitle',
+              trailing: Icon(YaruIcons.ubuntu_logo_simple),
+            ),
+            YaruTileList(
+              children: [
+                for (final canTap in [true, false]) ...[
+                  YaruListTile.square(
+                    enabled: canTap,
+                    titleText: 'YaruListTile',
+                    onTap: canTap ? () {} : null,
+                  ),
+                  YaruListTile.square(
+                    enabled: canTap,
+                    titleText: 'YaruListTile',
+                    subtitleText: 'YaruListTile subtitle',
+                    onTap: canTap ? () {} : null,
+                  ),
+                  YaruListTile.square(
+                    enabled: canTap,
+                    titleText: 'YaruListTile',
+                    subtitleText: 'YaruListTile subtitle',
+                    leading: const Icon(YaruIcons.ubuntu_logo_simple),
+                    onTap: canTap ? () {} : null,
+                  ),
+                  YaruListTile.square(
+                    enabled: canTap,
+                    titleText: 'YaruListTile',
+                    subtitleText: 'YaruListTile subtitle',
+                    trailing: const Icon(YaruIcons.ubuntu_logo_simple),
+                    onTap: canTap ? () {} : null,
+                  ),
+                ],
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/example/lib/pages/section_page.dart
+++ b/example/lib/pages/section_page.dart
@@ -23,7 +23,7 @@ class _SectionPageState extends State<SectionPage> {
           child: Column(
             children: [
               for (var i = 0; i < 10; ++i)
-                const YaruTile(
+                const YaruListTile(
                   title: Text('Title'),
                   trailing: Icon(YaruIcons.information),
                   leading: Icon(YaruIcons.music_note),
@@ -56,7 +56,7 @@ class DummySection extends StatelessWidget {
         ],
       ),
       width: width,
-      child: const YaruTile(
+      child: const YaruListTile(
         title: Text('Title'),
         trailing: Icon(YaruIcons.information),
         leading: Icon(YaruIcons.music_note),

--- a/example/lib/pages/split_button_page.dart
+++ b/example/lib/pages/split_button_page.dart
@@ -27,7 +27,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
     });
 
     final tiles = [
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton()'),
         subtitle: const Text('Regular version'),
         trailing: YaruSplitButton(
@@ -39,7 +39,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
           child: const Text('Main Action'),
         ),
       ),
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton'),
         subtitle: const Text('.filled()'),
         trailing: YaruSplitButton.filled(
@@ -51,7 +51,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
           child: const Text('Main Action'),
         ),
       ),
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton'),
         subtitle: const Text('outlined()'),
         trailing: YaruSplitButton.outlined(
@@ -63,7 +63,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
           child: const Text('Main Action'),
         ),
       ),
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton'),
         subtitle: const Text('items: null, onOptionPressed: null'),
         trailing: YaruSplitButton(
@@ -74,7 +74,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
           ).showSnackBar(const SnackBar(content: Text('Main Action'))),
         ),
       ),
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton'),
         subtitle: const Text('onPressed: null'),
         trailing: YaruSplitButton(
@@ -83,7 +83,7 @@ class _SplitButtonPageState extends State<SplitButtonPage> {
           child: const Text('Main Action'),
         ),
       ),
-      YaruTile(
+      YaruListTile(
         title: const Text('YaruSplitButton'),
         subtitle: const Text(
           'items: null, onOptionPressed: null, onPressed: null',

--- a/example/lib/pages/tile_page.dart
+++ b/example/lib/pages/tile_page.dart
@@ -11,6 +11,7 @@ class TilePage extends StatelessWidget {
         return ListView.builder(
           controller: controller,
           padding: const EdgeInsets.all(kYaruPagePadding),
+          // ignore: deprecated_member_use
           itemBuilder: (context, index) => const YaruTile(
             title: Text('Title'),
             trailing: Icon(YaruIcons.information),

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -55,3 +55,12 @@ extension on Brightness {
   Brightness get inverse =>
       this == Brightness.light ? Brightness.dark : Brightness.light;
 }
+
+extension WidgetIterableExtension on Iterable<Widget> {
+  List<Widget> separatedBy(Widget separator) {
+    return expand((item) sync* {
+      yield separator;
+      yield item;
+    }).skip(1).toList();
+  }
+}

--- a/lib/src/widgets/yaru_banner.dart
+++ b/lib/src/widgets/yaru_banner.dart
@@ -18,6 +18,7 @@ class YaruBanner extends StatelessWidget {
     this.hasFocusBorder,
   });
 
+  // ignore: deprecated_member_use_from_same_package
   /// Creates a banner with a [YaruTile] child widget.
   YaruBanner.tile({
     Key? key,
@@ -44,6 +45,7 @@ class YaruBanner extends StatelessWidget {
          selected: selected,
          mouseCursor: mouseCursor,
          hasFocusBorder: hasFocusBorder,
+         // ignore: deprecated_member_use_from_same_package
          child: YaruTile(
            leading: icon,
            title: title,

--- a/lib/src/widgets/yaru_border_container.dart
+++ b/lib/src/widgets/yaru_border_container.dart
@@ -19,6 +19,7 @@ class YaruBorderContainer extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.border,
     this.borderRadius,
+    this.borderStrokeAlign,
   });
 
   /// See [Container.child].
@@ -59,6 +60,9 @@ class YaruBorderContainer extends StatelessWidget {
   /// The default border is 1px wide and the color is [ThemeData.dividerColor].
   final BoxBorder? border;
 
+  /// See [BorderSide.strokeAlign]
+  final double? borderStrokeAlign;
+
   /// The border radius.
   ///
   /// The default border is circular with the radius of `kYaruContainerRadius`.
@@ -69,7 +73,10 @@ class YaruBorderContainer extends StatelessWidget {
     final theme = Theme.of(context);
     final effectiveBorder =
         border ??
-        Border.all(color: DividerTheme.of(context).color ?? theme.dividerColor);
+        Border.all(
+          color: DividerTheme.of(context).color ?? theme.dividerColor,
+          strokeAlign: borderStrokeAlign ?? BorderSide.strokeAlignInside,
+        );
     final effectiveBorderRadius =
         borderRadius ?? BorderRadius.circular(kYaruContainerRadius);
 

--- a/lib/src/widgets/yaru_list_tile.dart
+++ b/lib/src/widgets/yaru_list_tile.dart
@@ -119,7 +119,10 @@ class YaruListTile extends StatelessWidget {
                         : CrossAxisAlignment.start,
                     children: [
                       titleWidget,
-                      if (subtitleWidget != null) subtitleWidget,
+                      if (subtitleWidget != null) ...[
+                        subtitleWidget,
+                        const SizedBox(height: 1),
+                      ],
                     ],
                   ),
                 ),

--- a/lib/src/widgets/yaru_list_tile.dart
+++ b/lib/src/widgets/yaru_list_tile.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+class YaruListTile extends StatelessWidget {
+  const YaruListTile({
+    this.title,
+    this.titleText,
+    this.subtitle,
+    this.subtitleText,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.borderRadius,
+    this.hasFocusBorder,
+    this.centerTitle = false,
+    this.enabled = true,
+    this.horizontalGap = 12.0,
+    this.verticalGap = 8.0,
+    super.key,
+  }) : assert((title != null) ^ (titleText != null));
+
+  const YaruListTile.square({
+    this.title,
+    this.titleText,
+    this.subtitle,
+    this.subtitleText,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.hasFocusBorder,
+    this.borderRadius = BorderRadius.zero,
+    this.centerTitle = false,
+    this.enabled = true,
+    this.horizontalGap = 12.0,
+    this.verticalGap = 8.0,
+    super.key,
+  }) : assert((title != null) ^ (titleText != null));
+
+  /// The primary content of the list tile, displayed with [TextTheme.labelLarge].
+  final Widget? title;
+
+  final String? titleText;
+
+  /// Optional secondary content displayed below the title.
+  final Widget? subtitle;
+
+  final String? subtitleText;
+
+  /// A widget to display before the title.
+  final Widget? leading;
+
+  /// A widget to display after the title.
+  final Widget? trailing;
+
+  /// Called when the user taps this list tile.
+  final VoidCallback? onTap;
+
+  /// [BorderRadius] of the underlying [InkWell]
+  final BorderRadius? borderRadius;
+
+  /// Whether to display the default focus border on focus or not.
+  final bool? hasFocusBorder;
+
+  /// Whether to center the title text. Defaults to false.
+  final bool centerTitle;
+
+  /// Whether the list tile is enabled. Defaults to true.
+  final bool enabled;
+
+  /// Horizontal gap between widgets.
+  final double horizontalGap;
+
+  /// Vertical gap between widgets.
+  final double verticalGap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final titleWidget = DefaultTextStyle.merge(
+      style: theme.textTheme.labelLarge?.copyWith(
+        color: enabled ? null : theme.disabledColor,
+      ),
+      child: title ?? Text(titleText!),
+    );
+    final subtitleWidget = subtitle != null || subtitleText != null
+        ? DefaultTextStyle.merge(
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: enabled ? null : theme.disabledColor,
+            ),
+            child: subtitle ?? Text(subtitleText!),
+          )
+        : null;
+
+    final tile = ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 54),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius:
+              borderRadius ?? BorderRadius.circular(kYaruButtonRadius),
+          onTap: enabled ? onTap : null,
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: horizontalGap,
+              vertical: verticalGap,
+            ),
+            child: Row(
+              children: [
+                if (leading != null) ...[
+                  leading!,
+                  SizedBox(width: horizontalGap),
+                ],
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: centerTitle
+                        ? CrossAxisAlignment.center
+                        : CrossAxisAlignment.start,
+                    children: [
+                      titleWidget,
+                      if (subtitleWidget != null) subtitleWidget,
+                    ],
+                  ),
+                ),
+                if (trailing != null) ...[
+                  SizedBox(width: horizontalGap),
+                  trailing!,
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    return hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
+        ? YaruFocusBorder.primary(
+            borderStrokeAlign: BorderSide.strokeAlignInside,
+            child: tile,
+          )
+        : tile;
+  }
+}

--- a/lib/src/widgets/yaru_list_tile.dart
+++ b/lib/src/widgets/yaru_list_tile.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
+/// A tile widget similar to a [ListTile], with more flexible styling.
+///
+/// Using a [YaruListTile.square] is preferable when displaying the tiles inside
+/// a [YaruTileList].
 class YaruListTile extends StatelessWidget {
   const YaruListTile({
     this.title,
@@ -39,11 +43,13 @@ class YaruListTile extends StatelessWidget {
   /// The primary content of the list tile, displayed with [TextTheme.labelLarge].
   final Widget? title;
 
+  /// The text content of the title, mutually exclusive with [title].
   final String? titleText;
 
   /// Optional secondary content displayed below the title.
   final Widget? subtitle;
 
+  /// The text content of the subtitle, mutually exclusive with [subtitle].
   final String? subtitleText;
 
   /// A widget to display before the title.

--- a/lib/src/widgets/yaru_tile.dart
+++ b/lib/src/widgets/yaru_tile.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
+@deprecated
 enum YaruTileStyle { normal, banner }
 
+@Deprecated('Use YaruListTile instead')
 class YaruTile extends StatelessWidget {
   /// Creates a Yaru style [ListTile] similar widget.
   ///

--- a/lib/src/widgets/yaru_tile_list.dart
+++ b/lib/src/widgets/yaru_tile_list.dart
@@ -9,6 +9,7 @@ class YaruTileList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruBorderContainer(
+      borderStrokeAlign: BorderSide.strokeAlignOutside,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: children.separatedBy(const Divider()),

--- a/lib/src/widgets/yaru_tile_list.dart
+++ b/lib/src/widgets/yaru_tile_list.dart
@@ -9,7 +9,6 @@ class YaruTileList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruBorderContainer(
-      clipBehavior: Clip.hardEdge,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: children.separatedBy(const Divider()),

--- a/lib/src/widgets/yaru_tile_list.dart
+++ b/lib/src/widgets/yaru_tile_list.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
+/// A bordered, vertical list of widgets, separated by [Divider]s.
+///
+/// This widget is typically used to display [YaruListTile.square]s in a column.
 class YaruTileList extends StatelessWidget {
   const YaruTileList({required this.children, super.key});
 
+  /// See [Column.children].
   final List<Widget> children;
 
   @override

--- a/lib/src/widgets/yaru_tile_list.dart
+++ b/lib/src/widgets/yaru_tile_list.dart
@@ -14,6 +14,7 @@ class YaruTileList extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruBorderContainer(
       borderStrokeAlign: BorderSide.strokeAlignOutside,
+      clipBehavior: Clip.hardEdge,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: children.separatedBy(const Divider()),

--- a/lib/src/widgets/yaru_tile_list.dart
+++ b/lib/src/widgets/yaru_tile_list.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+class YaruTileList extends StatelessWidget {
+  const YaruTileList({required this.children, super.key});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return YaruBorderContainer(
+      clipBehavior: Clip.hardEdge,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: children.separatedBy(const Divider()),
+      ),
+    );
+  }
+}

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -28,6 +28,7 @@ export 'src/widgets/yaru_focus_border.dart';
 export 'src/widgets/yaru_icon_button.dart';
 export 'src/widgets/yaru_info.dart';
 export 'src/widgets/yaru_linear_progress_indicator.dart';
+export 'src/widgets/yaru_list_tile.dart';
 export 'src/widgets/yaru_option_button.dart';
 export 'src/widgets/yaru_page_indicator.dart';
 export 'src/widgets/yaru_page_indicator_layout_delegate.dart';

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -52,6 +52,7 @@ export 'src/widgets/yaru_switch_list_tile.dart';
 export 'src/widgets/yaru_switch_theme.dart';
 export 'src/widgets/yaru_tab_bar.dart';
 export 'src/widgets/yaru_tile.dart';
+export 'src/widgets/yaru_tile_list.dart';
 export 'src/widgets/yaru_title_bar.dart';
 export 'src/widgets/yaru_title_bar_theme.dart';
 export 'src/widgets/yaru_toggle_button.dart';

--- a/test/widgets/yaru_list_tile_test.dart
+++ b/test/widgets/yaru_list_tile_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaru/yaru.dart';
+
+void main() {
+  testWidgets('ltr layout', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: YaruListTile(
+            leading: Text('Leading'),
+            title: Text('Title'),
+            subtitle: Text('Subtitle'),
+            trailing: Text('Trailing'),
+          ),
+        ),
+      ),
+    );
+
+    final leading = find.text('Leading');
+    expect(leading, findsOneWidget);
+
+    final title = find.text('Title');
+    expect(title, findsOneWidget);
+
+    final subtitle = find.text('Subtitle');
+    expect(subtitle, findsOneWidget);
+
+    final trailing = find.text('Trailing');
+    expect(trailing, findsOneWidget);
+
+    expect(tester.getRect(leading).right, lessThan(tester.getRect(title).left));
+    expect(tester.getRect(title).left, equals(tester.getRect(subtitle).left));
+    expect(
+      tester.getRect(subtitle).top,
+      greaterThanOrEqualTo(tester.getRect(title).bottom),
+    );
+    expect(
+      tester.getRect(trailing).left,
+      greaterThan(tester.getRect(title).right),
+    );
+  });
+
+  testWidgets('rtl layout', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Directionality(
+            textDirection: TextDirection.rtl,
+            child: YaruListTile(
+              leading: Text('Leading'),
+              title: Text('Title'),
+              subtitle: Text('Subtitle'),
+              trailing: Text('Trailing'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final leading = find.text('Leading');
+    expect(leading, findsOneWidget);
+
+    final title = find.text('Title');
+    expect(title, findsOneWidget);
+
+    final subtitle = find.text('Subtitle');
+    expect(subtitle, findsOneWidget);
+
+    final trailing = find.text('Trailing');
+    expect(trailing, findsOneWidget);
+
+    expect(
+      tester.getRect(leading).left,
+      greaterThan(tester.getRect(title).right),
+    );
+    expect(tester.getRect(title).right, equals(tester.getRect(subtitle).right));
+    expect(
+      tester.getRect(subtitle).top,
+      greaterThanOrEqualTo(tester.getRect(title).bottom),
+    );
+    expect(
+      tester.getRect(trailing).right,
+      lessThan(tester.getRect(title).left),
+    );
+  });
+}

--- a/test/widgets/yaru_tile_test.dart
+++ b/test/widgets/yaru_tile_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yaru/src/widgets/yaru_tile.dart';


### PR DESCRIPTION
Adds the `YaruListTile` and `YaruTileList` widgets as described in https://github.com/ubuntu/yaru.dart/issues/1057.

`YaruListTile` could potentially just be named `YaruTile` and replace that widget, but it would have some breaking changes and design differences, so I've marked `YaruTile` as deprecated for now unless directed otherwise.

The `YaruTileList` is generally for displaying `YaruListTile`s in a bordered list, as you can see the bottom two-thirds of the example page:

| Dark | Light |
|------|-------|
| <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/bbf4343d-59e3-4c0d-913e-4b004747cdfe" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/129dfcd6-9c35-48de-8190-bbda7ec44a30" /> |

---

UDENG-8918