### PR TITLE
fix: Reduce non-focus input border width and remove backgrounds

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -39,7 +39,8 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
 
 InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final radius = BorderRadius.circular(kYaruButtonRadius);
-  const width = kYaruFocusBorderWidth;
+  const width = 1.0;
+  const focusWidth = kYaruFocusBorderWidth;
   const strokeAlign = 0.0;
   final fill = colorScheme.surface.scale(
     lightness: colorScheme.isLight ? -0.05 : -0.1,
@@ -52,14 +53,14 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   const textStyle = TextStyle(fontSize: 14, fontWeight: FontWeight.normal);
 
   return InputDecorationTheme(
-    filled: true,
+    filled: false,
     fillColor: fill,
     border: OutlineInputBorder(
       borderSide: BorderSide(width: width, color: border),
       borderRadius: radius,
     ),
     focusedBorder: OutlineInputBorder(
-      borderSide: BorderSide(width: width, color: colorScheme.primary),
+      borderSide: BorderSide(width: focusWidth, color: colorScheme.primary),
       borderRadius: radius,
     ),
     enabledBorder: OutlineInputBorder(
@@ -71,13 +72,13 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
       borderRadius: radius,
     ),
     activeIndicatorBorder: const BorderSide(
-      width: width,
+      width: focusWidth,
       strokeAlign: strokeAlign,
     ),
     outlineBorder: const BorderSide(width: width, strokeAlign: strokeAlign),
     focusedErrorBorder: OutlineInputBorder(
       borderSide: BorderSide(
-        width: width,
+        width: focusWidth,
         color: colorScheme.error,
         strokeAlign: strokeAlign,
       ),


### PR DESCRIPTION
Reduces the border around text inputs to 1 when not focused. Also removes the background color for them.

@juanruitina 

|       | Before | After |
|-------|--------|-------|
| Light | <img width="974" height="961" alt="image" src="https://github.com/user-attachments/assets/8b8a8895-9f37-4d09-9c7d-fe281e2e85ac" /> | <img width="974" height="961" alt="image" src="https://github.com/user-attachments/assets/351edd1d-0f72-4cfe-937f-bb475b9b697c" /> |
| Dark  | <img width="974" height="961" alt="image" src="https://github.com/user-attachments/assets/558678f9-4629-4e18-a222-8af21d753cd1" /> | <img width="974" height="961" alt="image" src="https://github.com/user-attachments/assets/24ae562e-1e8d-432f-ab73-1e801ab1afd8" /> |
