### PR TITLE
feat: Add option to hide the default popup icon

### DIFF
--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -77,7 +77,7 @@ class _PopupPageState extends State<PopupPage> {
                         enumSet.add(value);
                       }
                     },
-                    showIcon: false,
+                    showArrow: false,
                     child: const Icon(YaruIcons.view_more),
                     itemBuilder: (context) {
                       return [

--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -65,6 +65,40 @@ class _PopupPageState extends State<PopupPage> {
               children: [
                 const Padding(
                   padding: EdgeInsets.all(8.0),
+                  child: Text('With custom icon'),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: YaruPopupMenuButton<MyEnum>(
+                    onSelected: (value) {
+                      if (enumSet.contains(value)) {
+                        enumSet.remove(value);
+                      } else {
+                        enumSet.add(value);
+                      }
+                    },
+                    showIcon: false,
+                    child: const Icon(YaruIcons.view_more),
+                    itemBuilder: (context) {
+                      return [
+                        for (final value in MyEnum.values)
+                          YaruCheckedPopupMenuItem<MyEnum>(
+                            value: value,
+                            checked: enumSet.contains(value),
+                            child: Text(value.name),
+                          ),
+                      ];
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Card(
+            child: Column(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(8.0),
                   child: Text('With custom style'),
                 ),
                 Padding(

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -27,7 +27,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.mouseCursor,
     this.icon,
     this.semanticLabel,
-    this.showIcon = true,
+    this.showArrow = true,
   });
 
   final T? initialValue;
@@ -47,7 +47,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final ButtonStyle? style;
   final MouseCursor? mouseCursor;
   final Widget? icon;
-  final bool showIcon;
+  final bool showArrow;
   final String? semanticLabel;
 
   @override
@@ -104,7 +104,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
                       Padding(padding: childPadding, child: child),
                       SizedBox(
                         height: kYaruTitleBarItemHeight,
-                        child: showIcon
+                        child: showArrow
                             ? icon ??
                                   Icon(
                                     YaruIcons.pan_down,

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -27,6 +27,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.mouseCursor,
     this.icon,
     this.semanticLabel,
+    this.showIcon = true,
   });
 
   final T? initialValue;
@@ -46,6 +47,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final ButtonStyle? style;
   final MouseCursor? mouseCursor;
   final Widget? icon;
+  final bool showIcon;
   final String? semanticLabel;
 
   @override
@@ -102,13 +104,14 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
                       Padding(padding: childPadding, child: child),
                       SizedBox(
                         height: kYaruTitleBarItemHeight,
-                        child:
-                            icon ??
-                            Icon(
-                              YaruIcons.pan_down,
-                              color: style?.foregroundColor?.resolve({}),
-                              semanticLabel: semanticLabel,
-                            ),
+                        child: showIcon
+                            ? icon ??
+                                  Icon(
+                                    YaruIcons.pan_down,
+                                    color: style?.foregroundColor?.resolve({}),
+                                    semanticLabel: semanticLabel,
+                                  )
+                            : null,
                       ),
                     ],
                   ),


### PR DESCRIPTION
This is useful to be able to display *just* an icon (or anything else) as the popup menu button.

| Before | After |
|--------|-------|
| <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/cd9bdbc7-f4ca-4e6d-958a-9a9797e3f29c" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/20ec0b0e-f5e2-4dba-86c0-9d93ea153543" /> |

---

UDENG-9432