### PR TITLE
fix: Hide focus borders for nested list tile focuses

### DIFF
--- a/lib/src/widgets/yaru_checkbox_list_tile.dart
+++ b/lib/src/widgets/yaru_checkbox_list_tile.dart
@@ -75,6 +75,14 @@ class _YaruCheckboxListTileState extends State<YaruCheckboxListTile> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget? leading, trailing;
     final control =

--- a/lib/src/widgets/yaru_checkbox_list_tile.dart
+++ b/lib/src/widgets/yaru_checkbox_list_tile.dart
@@ -61,50 +61,70 @@ class YaruCheckboxListTile extends YaruToggleListTile {
   }
 
   @override
+  State<StatefulWidget> createState() => _YaruCheckboxListTileState();
+}
+
+class _YaruCheckboxListTileState extends State<YaruCheckboxListTile> {
+  bool _tileHasFocus = false;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = widget.focusNode ?? FocusNode();
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget? leading, trailing;
     final control =
-        this.control ??
+        widget.control ??
         YaruCheckbox(
-          value: value,
-          onChanged: onChanged,
-          autofocus: autofocus,
-          tristate: tristate,
-          mouseCursor: mouseCursor,
-          hasFocusBorder: false,
+          value: widget.value,
+          onChanged: widget.onChanged,
+          autofocus: widget.autofocus,
+          tristate: widget.tristate,
+          mouseCursor: widget.mouseCursor,
         );
 
-    switch (controlAffinity) {
+    switch (widget.controlAffinity) {
       case ListTileControlAffinity.leading:
       case ListTileControlAffinity.platform:
         leading = control;
-        trailing = secondary;
+        trailing = widget.secondary;
         break;
       case ListTileControlAffinity.trailing:
-        leading = secondary;
+        leading = widget.secondary;
         trailing = control;
         break;
     }
 
     final tile = YaruListTile(
       leading: leading,
-      title: title,
-      subtitle: subtitle,
+      title: widget.title,
+      subtitle: widget.subtitle,
       trailing: trailing,
-      enabled: onChanged != null,
-      onTap: onChanged != null ? _handleValueChange : null,
-      autofocus: autofocus,
-      customBorder: shape,
-      focusNode: focusNode,
-      enableFeedback: enableFeedback,
-      mouseCursor: mouseCursor,
-      contentPadding: contentPadding,
+      enabled: widget.onChanged != null,
+      onTap: widget.onChanged != null ? widget._handleValueChange : null,
+      autofocus: widget.autofocus,
+      customBorder: widget.shape,
+      focusNode: _focusNode,
+      enableFeedback: widget.enableFeedback,
+      mouseCursor: widget.mouseCursor,
+      contentPadding: widget.contentPadding,
+      hasFocusBorder: false,
+      onFocusChange: (focus) => setState(() {
+        _tileHasFocus = _focusNode.hasPrimaryFocus;
+      }),
     );
 
     return MergeSemantics(
-      child: hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
+      child:
+          widget.hasFocusBorder ??
+              YaruTheme.maybeOf(context)?.focusBorders == true
           ? YaruFocusBorder.primary(
               borderStrokeAlign: BorderSide.strokeAlignInside,
+              borderColor: _tileHasFocus ? null : Colors.transparent,
               child: tile,
             )
           : tile,

--- a/lib/src/widgets/yaru_list_tile.dart
+++ b/lib/src/widgets/yaru_list_tile.dart
@@ -21,6 +21,7 @@ class YaruListTile extends StatelessWidget {
     this.hasFocusBorder,
     this.mouseCursor,
     this.focusNode,
+    this.onFocusChange,
     this.hoverColor,
     this.customBorder,
     this.centerTitle = false,
@@ -44,6 +45,7 @@ class YaruListTile extends StatelessWidget {
     this.hasFocusBorder,
     this.mouseCursor,
     this.focusNode,
+    this.onFocusChange,
     this.hoverColor,
     this.customBorder,
     this.borderRadius = BorderRadius.zero,
@@ -105,6 +107,8 @@ class YaruListTile extends StatelessWidget {
   /// See [InkWell.focusNode].
   final FocusNode? focusNode;
 
+  final void Function(bool)? onFocusChange;
+
   /// See [InkWell.enableFeedback].
   final bool enableFeedback;
 
@@ -146,6 +150,7 @@ class YaruListTile extends StatelessWidget {
           onTap: enabled ? onTap : null,
           mouseCursor: mouseCursor,
           focusNode: focusNode,
+          onFocusChange: onFocusChange,
           enableFeedback: enableFeedback,
           hoverColor: hoverColor,
           autofocus: autofocus,

--- a/lib/src/widgets/yaru_radio_list_tile.dart
+++ b/lib/src/widgets/yaru_radio_list_tile.dart
@@ -74,6 +74,14 @@ class _YaruRadioListTileState<T> extends State<YaruRadioListTile<T>> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget? leading, trailing;
     final control =

--- a/lib/src/widgets/yaru_radio_list_tile.dart
+++ b/lib/src/widgets/yaru_radio_list_tile.dart
@@ -60,51 +60,71 @@ class YaruRadioListTile<T> extends YaruToggleListTile {
   }
 
   @override
+  State<StatefulWidget> createState() => _YaruRadioListTileState<T>();
+}
+
+class _YaruRadioListTileState<T> extends State<YaruRadioListTile<T>> {
+  bool _tileHasFocus = false;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = widget.focusNode ?? FocusNode();
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget? leading, trailing;
     final control =
-        this.control ??
+        widget.control ??
         YaruRadio<T>(
-          value: value,
-          groupValue: groupValue,
-          onChanged: onChanged,
-          toggleable: toggleable,
-          autofocus: autofocus,
-          mouseCursor: mouseCursor,
-          hasFocusBorder: false,
+          value: widget.value,
+          groupValue: widget.groupValue,
+          onChanged: widget.onChanged,
+          toggleable: widget.toggleable,
+          autofocus: widget.autofocus,
+          mouseCursor: widget.mouseCursor,
         );
 
-    switch (controlAffinity) {
+    switch (widget.controlAffinity) {
       case ListTileControlAffinity.leading:
       case ListTileControlAffinity.platform:
         leading = control;
-        trailing = secondary;
+        trailing = widget.secondary;
         break;
       case ListTileControlAffinity.trailing:
-        leading = secondary;
+        leading = widget.secondary;
         trailing = control;
         break;
     }
 
     final tile = YaruListTile(
       leading: leading,
-      title: title,
-      subtitle: subtitle,
+      title: widget.title,
+      subtitle: widget.subtitle,
       trailing: trailing,
-      enabled: onChanged != null,
-      onTap: onChanged != null ? _handleValueChange : null,
-      autofocus: autofocus,
-      focusNode: focusNode,
-      hoverColor: hoverColor,
-      mouseCursor: mouseCursor,
-      customBorder: shape,
-      contentPadding: contentPadding,
+      enabled: widget.onChanged != null,
+      onTap: widget.onChanged != null ? widget._handleValueChange : null,
+      autofocus: widget.autofocus,
+      focusNode: _focusNode,
+      hoverColor: widget.hoverColor,
+      mouseCursor: widget.mouseCursor,
+      customBorder: widget.shape,
+      contentPadding: widget.contentPadding,
+      hasFocusBorder: false,
+      onFocusChange: (focus) => setState(() {
+        _tileHasFocus = _focusNode.hasPrimaryFocus;
+      }),
     );
 
     return MergeSemantics(
-      child: hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
+      child:
+          widget.hasFocusBorder ??
+              YaruTheme.maybeOf(context)?.focusBorders == true
           ? YaruFocusBorder.primary(
               borderStrokeAlign: BorderSide.strokeAlignInside,
+              borderColor: _tileHasFocus ? null : Colors.transparent,
               child: tile,
             )
           : tile,

--- a/lib/src/widgets/yaru_switch_list_tile.dart
+++ b/lib/src/widgets/yaru_switch_list_tile.dart
@@ -44,55 +44,75 @@ class YaruSwitchListTile extends YaruToggleListTile {
   final ValueChanged<bool>? onChanged;
 
   @override
+  State<StatefulWidget> createState() => _YaruSwitchListTileState();
+}
+
+class _YaruSwitchListTileState extends State<YaruSwitchListTile> {
+  bool _tileHasFocus = false;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = widget.focusNode ?? FocusNode();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final control =
-        this.control ??
+        widget.control ??
         YaruSwitch(
-          value: value,
-          onChanged: onChanged,
-          autofocus: autofocus,
-          mouseCursor: mouseCursor,
-          onOffShapes: onOffShapes,
-          hasFocusBorder: false,
+          value: widget.value,
+          onChanged: widget.onChanged,
+          autofocus: widget.autofocus,
+          mouseCursor: widget.mouseCursor,
+          onOffShapes: widget.onOffShapes,
         );
 
     Widget? leading, trailing;
-    switch (controlAffinity) {
+    switch (widget.controlAffinity) {
       case ListTileControlAffinity.leading:
         leading = control;
-        trailing = secondary;
+        trailing = widget.secondary;
         break;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
-        leading = secondary;
+        leading = widget.secondary;
         trailing = control;
         break;
     }
 
     final tile = YaruListTile(
       leading: leading,
-      title: title,
-      subtitle: subtitle,
+      title: widget.title,
+      subtitle: widget.subtitle,
       trailing: trailing,
-      enabled: onChanged != null,
-      onTap: onChanged != null
+      enabled: widget.onChanged != null,
+      onTap: widget.onChanged != null
           ? () {
-              onChanged!(!value);
+              widget.onChanged!(!widget.value);
             }
           : null,
-      autofocus: autofocus,
-      focusNode: focusNode,
-      enableFeedback: enableFeedback,
-      hoverColor: hoverColor,
-      mouseCursor: mouseCursor,
-      customBorder: shape,
-      contentPadding: contentPadding,
+      autofocus: widget.autofocus,
+      focusNode: _focusNode,
+      enableFeedback: widget.enableFeedback,
+      hoverColor: widget.hoverColor,
+      mouseCursor: widget.mouseCursor,
+      customBorder: widget.shape,
+      contentPadding: widget.contentPadding,
+      hasFocusBorder: false,
+      onFocusChange: (focus) => setState(() {
+        _tileHasFocus = _focusNode.hasPrimaryFocus;
+      }),
     );
 
     return MergeSemantics(
-      child: hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
+      child:
+          widget.hasFocusBorder ??
+              YaruTheme.maybeOf(context)?.focusBorders == true
           ? YaruFocusBorder.primary(
               borderStrokeAlign: BorderSide.strokeAlignInside,
+              borderColor: _tileHasFocus ? null : Colors.transparent,
               child: tile,
             )
           : tile,

--- a/lib/src/widgets/yaru_switch_list_tile.dart
+++ b/lib/src/widgets/yaru_switch_list_tile.dart
@@ -58,6 +58,14 @@ class _YaruSwitchListTileState extends State<YaruSwitchListTile> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final control =
         widget.control ??

--- a/lib/src/widgets/yaru_toggle_list_tile.dart
+++ b/lib/src/widgets/yaru_toggle_list_tile.dart
@@ -3,7 +3,7 @@ import 'package:yaru/yaru.dart';
 
 /// Abstract class for toggleable list tiles like [YaruRadioListTile],
 /// [YaruCheckboxListTile], and [YaruSwitchListTile].
-abstract class YaruToggleListTile<T> extends StatelessWidget {
+abstract class YaruToggleListTile<T> extends StatefulWidget {
   const YaruToggleListTile({
     super.key,
     this.control,


### PR DESCRIPTION
Hides list tile focus borders when one if its children is focused, and not the tile. This is more consistent with GTK behavior.

| Before | After |
|--------|-------|
| <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/b13063b2-d6ad-4a93-ad73-6013c1ad4835" /> <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/e9e2bc67-1b6e-43fe-adfe-7a3ddad9ef63" /> | <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/450c3b64-c4a5-463c-b6a1-8ef627e9991e" /> <img width="752" height="772" alt="image" src="https://github.com/user-attachments/assets/7b9908e5-d63b-4c08-abd3-7003ad25c83b" /> |

---

UDENG-9317