### PR TITLE
fix: Minimize YaruSplitButton width

### DIFF
--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -169,6 +169,7 @@ class YaruSplitButton extends StatelessWidget {
 
     return IntrinsicHeight(
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true


### PR DESCRIPTION
Sets the main axis size for split buttons to `MainAxisSize.min` so that they don't take up unnecessary space.

---

UDENG-9615