### PR TITLE
fix: remove `TextStyle.package` to allow `copyWith` to change the font

### DIFF
--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -110,9 +110,8 @@ class _CodeDialogState extends State<_CodeDialog> {
                         : vsTheme,
                     padding: const EdgeInsets.all(12),
                     textStyle: const TextStyle(
-                      fontFamily: 'UbuntuMono',
+                      fontFamily: 'packages/yaru/UbuntuMono',
                       fontSize: 16,
-                      package: 'yaru',
                     ),
                   ),
                 );

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -7,7 +7,7 @@ import 'text_theme.dart';
 
 // AppBar
 
-AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
+AppBarTheme _createAppBarTheme(ColorScheme colorScheme, TextTheme textTheme) {
   return AppBarTheme(
     shape: Border(
       bottom: BorderSide(
@@ -27,7 +27,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
         : SystemUiOverlayStyle.dark,
     backgroundColor: colorScheme.surface,
     foregroundColor: colorScheme.onSurface,
-    titleTextStyle: createTextTheme(colorScheme.onSurface).titleLarge!.copyWith(
+    titleTextStyle: textTheme.titleLarge!.copyWith(
       color: colorScheme.onSurface,
       fontWeight: FontWeight.normal,
     ),
@@ -740,7 +740,7 @@ ThemeData createYaruTheme({
     checkboxTheme: _createCheckBoxTheme(colorScheme),
     radioTheme: _createRadioTheme(colorScheme),
     primaryColorDark: colorScheme.isDark ? colorScheme.primary : null,
-    appBarTheme: _createAppBarTheme(colorScheme),
+    appBarTheme: _createAppBarTheme(colorScheme, textTheme),
     floatingActionButtonTheme: _createFloatingActionButtonTheme(
       colorScheme,
       elevatedButtonColor,

--- a/lib/src/themes/text_theme.dart
+++ b/lib/src/themes/text_theme.dart
@@ -86,8 +86,7 @@ class _UbuntuTextStyle extends TextStyle {
     super.fontWeight,
     required this.textColor,
   }) : super(
-         fontFamily: 'Ubuntu',
-         package: 'yaru',
+         fontFamily: 'packages/yaru/Ubuntu',
          color: textColor,
          letterSpacing: 0, // Override Material/Flutter's letter spacing
        );

--- a/test/foundation/yaru_text_theme_test.dart
+++ b/test/foundation/yaru_text_theme_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+import 'package:yaru/src/themes/text_theme.dart';
+
+void main() {
+  group('TextTheme', () {
+    test('Package does not affect fontFamilyFallback', () {
+      var textStyle = createTextTheme(Colors.black).bodyMedium!;
+      textStyle = textStyle.copyWith(fontFamilyFallback: ['Adwaita Sans']);
+      expect(
+        textStyle.fontFamilyFallback,
+        ['Adwaita Sans'],
+        reason:
+            'If TextStyle.package is non-null, it is incorrectly applied to fontFamilyFallback.\n'
+            'Remove TextStyle.package.',
+      );
+    });
+    test('Font can be overridden with copyWith()', () {
+      var textStyle = createTextTheme(Colors.black).bodyMedium!;
+      expect(textStyle.fontFamily, 'packages/yaru/Ubuntu');
+      textStyle = textStyle.copyWith(fontFamily: 'Adwaita Sans', package: null);
+      expect(
+        textStyle.fontFamily,
+        'Adwaita Sans',
+        reason:
+            'If TextStyle.package is non-null, it can\'t be overridden with copyWith().\n'
+            'Remove TextStyle.package.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
This package's use of `TextStyle.package` causes problems when apps don't want to use the bundled Ubuntu font.

### Problem

The ideal approach to change the font would be something like
```dart
textStyle = textStyle.copyWith(fontFamily: 'MyNonYaruFont', package: null);
```
But the implementation of copyWith cannot remove textStyle.package, leading to the new fontFamily being `packages/yaru/MyNonYaruFont`.

Users of this package currently need to use workarounds like:
1. Make a function similar to `copyWith` that explicitly removes the `package` field:
   [<img width="400" src="https://github.com/user-attachments/assets/787e75be-a001-4f8f-9eb9-99625c0cb3a6" /> 🔗](https://github.com/adil192/no_more_background/blob/201e3ab3ebfda19953d5419bb6c0d80b2f24d9b4/lib/main.dart#L181-L225)
   But not only is this verbose, but it's likely to break in time as new fields are added to TextStyle.

2. Ditch Yaru's TextTheme completely, and use the default Flutter TextTheme:
   [<img width="400" src="https://github.com/user-attachments/assets/c7ee91c5-7f65-4298-a735-817e20b6888f" /> 🔗](https://github.com/saber-notes/saber/blob/4088ad373c4a1ac83a752aaabb00e0dc58e9a2a1/lib/components/theming/saber_theme.dart#L134-L154)
   But of course, we then lose Yaru's TextTheme :(.
   Also see https://github.com/ubuntu/yaru.dart/issues/905.

### Solution

This PR simply replaces `TextStyle(fontFamily: 'Ubuntu', package: 'yaru')` with `TextStyle(fontFamily: 'packages/yaru/Ubuntu')` which is functionally identical except resolving the issue stated above.
This lets apps choose their own fonts without messy boilerplate.

Unit tests have been added for this problem.
