### PR TITLE
feat: accept fontFamily parameter in createYaruTheme

### DIFF
--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -110,9 +110,8 @@ class _CodeDialogState extends State<_CodeDialog> {
                         : vsTheme,
                     padding: const EdgeInsets.all(12),
                     textStyle: const TextStyle(
-                      fontFamily: 'UbuntuMono',
+                      fontFamily: 'packages/yaru/UbuntuMono',
                       fontSize: 16,
-                      package: 'yaru',
                     ),
                   ),
                 );

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -7,7 +7,7 @@ import 'text_theme.dart';
 
 // AppBar
 
-AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
+AppBarTheme _createAppBarTheme(ColorScheme colorScheme, TextTheme textTheme) {
   return AppBarTheme(
     shape: Border(
       bottom: BorderSide(
@@ -27,7 +27,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
         : SystemUiOverlayStyle.dark,
     backgroundColor: colorScheme.surface,
     foregroundColor: colorScheme.onSurface,
-    titleTextStyle: createTextTheme(colorScheme.onSurface).titleLarge!.copyWith(
+    titleTextStyle: textTheme.titleLarge!.copyWith(
       color: colorScheme.onSurface,
       fontWeight: FontWeight.normal,
     ),
@@ -685,11 +685,17 @@ ThemeData createYaruTheme({
   Color? elevatedButtonColor,
   Color? elevatedButtonTextColor,
   bool? useMaterial3 = true,
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
 }) {
   final dividerColor = colorScheme.isHighContrast
       ? colorScheme.outlineVariant
       : colorScheme.outline.scale(lightness: colorScheme.isLight ? 0.1 : -0.06);
-  final textTheme = createTextTheme(colorScheme.onSurface);
+  final textTheme = createTextTheme(
+    textColor: colorScheme.onSurface,
+    fontFamily: fontFamily,
+    fontFamilyFallback: fontFamilyFallback,
+  );
 
   final themeData = ThemeData.from(
     useMaterial3: useMaterial3,
@@ -740,7 +746,7 @@ ThemeData createYaruTheme({
     checkboxTheme: _createCheckBoxTheme(colorScheme),
     radioTheme: _createRadioTheme(colorScheme),
     primaryColorDark: colorScheme.isDark ? colorScheme.primary : null,
-    appBarTheme: _createAppBarTheme(colorScheme),
+    appBarTheme: _createAppBarTheme(colorScheme, textTheme),
     floatingActionButtonTheme: _createFloatingActionButtonTheme(
       colorScheme,
       elevatedButtonColor,
@@ -835,6 +841,8 @@ ThemeData createYaruLightTheme({
   Color? elevatedButtonColor,
   Color? elevatedButtonTextColor,
   bool? useMaterial3 = true,
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
 }) {
   final secondary = primaryColor.scale(lightness: 0.2).cap(saturation: .9);
   final secondaryContainer = primaryColor
@@ -881,6 +889,8 @@ ThemeData createYaruLightTheme({
     elevatedButtonColor: elevatedButtonColor,
     elevatedButtonTextColor: elevatedButtonTextColor,
     useMaterial3: useMaterial3,
+    fontFamily: fontFamily,
+    fontFamilyFallback: fontFamilyFallback,
   );
 }
 
@@ -894,6 +904,8 @@ ThemeData createYaruDarkTheme({
   Color? elevatedButtonTextColor,
   bool? useMaterial3 = true,
   bool highContrast = false,
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
 }) {
   final secondary = primaryColor.scale(lightness: -0.3, saturation: -0.15);
   final secondaryContainer = primaryColor
@@ -939,5 +951,7 @@ ThemeData createYaruDarkTheme({
     elevatedButtonColor: elevatedButtonColor,
     elevatedButtonTextColor: elevatedButtonTextColor,
     useMaterial3: useMaterial3,
+    fontFamily: fontFamily,
+    fontFamilyFallback: fontFamilyFallback,
   );
 }

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -7,7 +7,10 @@ import 'text_theme.dart';
 
 // AppBar
 
-AppBarTheme _createAppBarTheme(ColorScheme colorScheme, TextTheme textTheme) {
+AppBarTheme _createAppBarTheme({
+  required ColorScheme colorScheme,
+  required TextTheme textTheme,
+}) {
   return AppBarTheme(
     shape: Border(
       bottom: BorderSide(
@@ -746,7 +749,10 @@ ThemeData createYaruTheme({
     checkboxTheme: _createCheckBoxTheme(colorScheme),
     radioTheme: _createRadioTheme(colorScheme),
     primaryColorDark: colorScheme.isDark ? colorScheme.primary : null,
-    appBarTheme: _createAppBarTheme(colorScheme, textTheme),
+    appBarTheme: _createAppBarTheme(
+      colorScheme: colorScheme,
+      textTheme: textTheme,
+    ),
     floatingActionButtonTheme: _createFloatingActionButtonTheme(
       colorScheme,
       elevatedButtonColor,

--- a/lib/src/themes/text_theme.dart
+++ b/lib/src/themes/text_theme.dart
@@ -1,81 +1,115 @@
 import 'package:flutter/material.dart';
 
-TextTheme createTextTheme(Color textColor) {
+TextTheme createTextTheme({
+  required Color textColor,
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
+}) {
   return TextTheme(
     displayLarge: _UbuntuTextStyle(
       fontSize: 96,
       fontWeight: FontWeight.w300,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     displayMedium: _UbuntuTextStyle(
       fontSize: 60,
       fontWeight: FontWeight.w300,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     displaySmall: _UbuntuTextStyle(
       fontSize: 48,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     headlineLarge: _UbuntuTextStyle(
       fontSize: 40,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     headlineMedium: _UbuntuTextStyle(
       fontSize: 34,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     headlineSmall: _UbuntuTextStyle(
       fontSize: 24,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     titleLarge: _UbuntuTextStyle(
       fontSize: 20,
       fontWeight: FontWeight.w500,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     titleMedium: _UbuntuTextStyle(
       fontSize: 16,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     titleSmall: _UbuntuTextStyle(
       fontSize: 14.66,
       fontWeight: FontWeight.w500,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     bodyLarge: _UbuntuTextStyle(
       fontSize: 16,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     bodyMedium: _UbuntuTextStyle(
       fontSize: 14.66,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     bodySmall: _UbuntuTextStyle(
       fontSize: 12,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     labelLarge: _UbuntuTextStyle(
       fontSize: 14.66,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     labelMedium: _UbuntuTextStyle(
       fontSize: 12,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
     labelSmall: _UbuntuTextStyle(
       fontSize: 10,
       fontWeight: FontWeight.normal,
-      textColor: textColor,
+      color: textColor,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
     ),
   );
 }
@@ -84,12 +118,11 @@ class _UbuntuTextStyle extends TextStyle {
   const _UbuntuTextStyle({
     super.fontSize,
     super.fontWeight,
-    required this.textColor,
+    required Color super.color,
+    String? fontFamily,
+    super.fontFamilyFallback,
   }) : super(
-         fontFamily: 'Ubuntu',
-         package: 'yaru',
-         color: textColor,
+         fontFamily: fontFamily ?? 'packages/yaru/Ubuntu',
          letterSpacing: 0, // Override Material/Flutter's letter spacing
        );
-  final Color textColor;
 }

--- a/test/foundation/yaru_text_theme_test.dart
+++ b/test/foundation/yaru_text_theme_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+import 'package:yaru/src/themes/common_themes.dart';
+import 'package:yaru/src/themes/text_theme.dart';
+
+void main() {
+  group('TextTheme', () {
+    test('Package does not affect fontFamilyFallback', () {
+      var textStyle = createTextTheme(textColor: Colors.black).bodyMedium!;
+      textStyle = textStyle.copyWith(fontFamilyFallback: ['Adwaita Sans']);
+      expect(
+        textStyle.fontFamilyFallback,
+        ['Adwaita Sans'],
+        reason:
+            'If TextStyle.package is non-null, it is incorrectly applied to fontFamilyFallback.\n'
+            'Remove TextStyle.package.',
+      );
+    });
+    test('Font can be overridden with copyWith()', () {
+      var textStyle = createTextTheme(textColor: Colors.black).bodyMedium!;
+      expect(textStyle.fontFamily, 'packages/yaru/Ubuntu');
+      textStyle = textStyle.copyWith(fontFamily: 'Adwaita Sans', package: null);
+      expect(
+        textStyle.fontFamily,
+        'Adwaita Sans',
+        reason:
+            'If TextStyle.package is non-null, it can\'t be overridden with copyWith().\n'
+            'Remove TextStyle.package.',
+      );
+    });
+
+    test('Font is propagated across components', () {
+      final theme = createYaruTheme(
+        colorScheme: const ColorScheme.light(),
+        fontFamily: 'Adwaita Sans',
+        fontFamilyFallback: ['Cantarell'],
+      );
+
+      final bodyMedium = theme.textTheme.bodyMedium!;
+      expect(bodyMedium.fontFamily, 'Adwaita Sans');
+      expect(bodyMedium.fontFamilyFallback, ['Cantarell']);
+
+      final appBarStyle = theme.appBarTheme.titleTextStyle!;
+      expect(appBarStyle.fontFamily, 'Adwaita Sans');
+      expect(appBarStyle.fontFamilyFallback, ['Cantarell']);
+
+      final menuButtonStyle = theme.menuButtonTheme.style!.textStyle!.resolve(
+        {},
+      )!;
+      expect(menuButtonStyle.fontFamily, 'Adwaita Sans');
+      expect(menuButtonStyle.fontFamilyFallback, ['Cantarell']);
+
+      final listTileTitle = theme.listTileTheme.titleTextStyle!;
+      expect(listTileTitle.fontFamily, 'Adwaita Sans');
+      expect(listTileTitle.fontFamilyFallback, ['Cantarell']);
+
+      final listTileSubtitle = theme.listTileTheme.subtitleTextStyle!;
+      expect(listTileSubtitle.fontFamily, 'Adwaita Sans');
+      expect(listTileSubtitle.fontFamilyFallback, ['Cantarell']);
+
+      final chipStyle = theme.chipTheme.labelStyle!;
+      expect(chipStyle.fontFamily, 'Adwaita Sans');
+      expect(chipStyle.fontFamilyFallback, ['Cantarell']);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds font parameters to `createYaruTheme`, `createYaruLightTheme`, and `createYaruDarkTheme`.

When the theme is created, its text theme is passed around to several `...ThemeData` classes, making it difficult to completely override the font later.
Adding the parameters right at the start fixes this issue.
This has no impact on YaruVariant.

I had to workaround this recently in https://github.com/saber-notes/saber/commit/a4531475c4b2cd0c28ed2ad7ccca2478b98248ef. Note that changing the font isn't purely aesthetic, but is sometimes needed for language support.

