### PR TITLE
feat: add expanded option to YaruSplitButton

### DIFF
--- a/lib/src/widgets/yaru_split_button.dart
+++ b/lib/src/widgets/yaru_split_button.dart
@@ -16,6 +16,7 @@ class YaruSplitButton extends StatelessWidget {
     this.radius,
     this.menuWidth,
     this.hasFocusBorder,
+    this.expanded = false,
   }) : _variant = _YaruSplitButtonVariant.elevated;
 
   const YaruSplitButton.filled({
@@ -29,6 +30,7 @@ class YaruSplitButton extends StatelessWidget {
     this.radius,
     this.menuWidth,
     this.hasFocusBorder,
+    this.expanded = false,
   }) : _variant = _YaruSplitButtonVariant.filled;
 
   const YaruSplitButton.outlined({
@@ -42,6 +44,7 @@ class YaruSplitButton extends StatelessWidget {
     this.radius,
     this.menuWidth,
     this.hasFocusBorder,
+    this.expanded = false,
   }) : _variant = _YaruSplitButtonVariant.outlined;
 
   final _YaruSplitButtonVariant _variant;
@@ -54,6 +57,7 @@ class YaruSplitButton extends StatelessWidget {
   final double? radius;
   final double? menuWidth;
   final bool? hasFocusBorder;
+  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
@@ -167,17 +171,22 @@ class YaruSplitButton extends StatelessWidget {
       ),
     };
 
+    final mainButtonWithFocusBorder =
+        hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
+        ? YaruFocusBorder.primary(
+            borderRadius: mainBorderRadius,
+            child: mainButton,
+          )
+        : mainButton;
+
     return IntrinsicHeight(
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          hasFocusBorder ?? YaruTheme.maybeOf(context)?.focusBorders == true
-              ? YaruFocusBorder.primary(
-                  borderRadius: mainBorderRadius,
-                  child: mainButton,
-                )
-              : mainButton,
+          expanded
+              ? Expanded(child: mainButtonWithFocusBorder)
+              : mainButtonWithFocusBorder,
           if (onDropdownPressed != null) ...[
             if (_variant != _YaruSplitButtonVariant.outlined)
               const SizedBox(width: 1),


### PR DESCRIPTION
Add's an `expanded` flag (defaults false for backwards compatability) that allows for the main action button to fill the width given by its parent. This will help solve a an issue in the prompting client where it is difficult to get to YaruSplitButtons side by side with equal width if the text is different in length.

For example with the prompting client, it allows for:
### Before
<img width="375" height="682" alt="Screenshot From 2026-06-03 16-45-35" src="https://github.com/user-attachments/assets/625f066a-aaf3-4fae-9fcf-39cab9a91009" />
<img width="375" height="682" alt="Screenshot From 2026-06-03 16-55-36" src="https://github.com/user-attachments/assets/0690661b-acfc-4a4d-bf36-fa9086a47c30" />

### After
<img width="375" height="682" alt="Screenshot From 2026-06-03 16-46-32" src="https://github.com/user-attachments/assets/fbbaad48-69a1-41b7-bb93-b04201d2485b" />
<img width="375" height="682" alt="Screenshot From 2026-06-03 16-53-31" src="https://github.com/user-attachments/assets/13b83296-1032-463d-a14b-71cc66d4df03" />

